### PR TITLE
build(DEV-4840): fix docker files for Memory and Oldowan Servers

### DIFF
--- a/MemoryServer.Dockerfile
+++ b/MemoryServer.Dockerfile
@@ -5,9 +5,10 @@ COPY ./ .
 
 # Install dependencies at root level first
 RUN bun install
-
-RUN bun run build
-
+# Build packages in dependency order
+RUN bun run --filter @elite-agents/machina-habilis build
+RUN bun run --filter @elite-agents/oldowan build
+RUN bun run --filter @elite-agents/mnemon build
 
 # Setup for running
 WORKDIR /app/apps/example-memory-server

--- a/OldowanServer.Dockerfile
+++ b/OldowanServer.Dockerfile
@@ -6,8 +6,9 @@ COPY ./ .
 # Install dependencies at root level first
 RUN bun install
 
-RUN bun run build
-
+# Build packages in dependency order
+RUN bun run --filter @elite-agents/machina-habilis build
+RUN bun run --filter @elite-agents/oldowan build
 
 # Setup for running
 WORKDIR /app/apps/example-oldowan-server


### PR DESCRIPTION
build order matters, otherwise the types for dependencies may not exist during build time.  