### PR TITLE
feat(DEV-4807): implement llm text streaming

### DIFF
--- a/apps/machina-habilis-builder/src/components/ChatInterface.tsx
+++ b/apps/machina-habilis-builder/src/components/ChatInterface.tsx
@@ -12,6 +12,7 @@ const ChatInterface = () => {
   const { selectedAgent } = useAgents();
   const [message, setMessage] = useState('');
   const [chatHistory, setChatHistory] = useState<IChatHistory[]>([]);
+  const [streamedMessage, setStreamedMessage] = useState('');
 
   useEffect(() => {
     setChatHistory([]);
@@ -47,11 +48,15 @@ const ChatInterface = () => {
       {
         channelId: 'machina-habilis-builder',
         callback: handleAgentResponse,
+        streamTextHandler: (text) => {
+          setStreamedMessage((streamedMsg) => (streamedMsg += text));
+        },
       },
     );
 
     if (chatResponse) {
       handleAgentResponse(chatResponse);
+      setStreamedMessage('');
     }
   };
 
@@ -85,6 +90,15 @@ const ChatInterface = () => {
             </div>
           </div>
         ))}
+        {streamedMessage && (
+          <div className={`flex justify-start`}>
+            <div
+              className={`max-w-[80%] rounded-lg px-4 py-2 bg-gray-800 text-gray-200`}
+            >
+              {streamedMessage}
+            </div>
+          </div>
+        )}
       </div>
 
       <form onSubmit={handleSendMessage} className="relative">

--- a/packages/machina-habilis/src/machina.ts
+++ b/packages/machina-habilis/src/machina.ts
@@ -44,6 +44,7 @@ export class MachinaAgent implements IMachinaAgent {
     opts?: {
       channelId?: string;
       callback?: (lifecycle: IMessageLifecycle) => void;
+      streamTextHandler?: (text: string) => void;
     },
   ): Promise<IMessageLifecycle> {
     let lifecycle: IMessageLifecycle = {
@@ -94,7 +95,12 @@ export class MachinaAgent implements IMachinaAgent {
     while (continuePrompting && promptCount < MAX_PROMPTS) {
       promptCount++;
 
-      openaiResponse = await invokeLLM(this.llm, lifecycle, tools);
+      openaiResponse = await invokeLLM(
+        this.llm,
+        lifecycle,
+        tools,
+        opts?.streamTextHandler,
+      );
 
       console.log('OpenAI Response:', openaiResponse);
 


### PR DESCRIPTION
- tested vercel ai sdk - had to create a backend endpoint that creates the stream (see [docs example](https://sdk.vercel.ai/docs/ai-sdk-ui/stream-protocol#data-stream-example)), works well but i'm not sure how to incorporate this to machina-habilis package.
- if we use vercel ai sdk, seems like we'd also have to refactor how we pass toolings ([see docs here](https://sdk.vercel.ai/docs/foundations/tools)) and utilize them (see [tools usage docs here](https://sdk.vercel.ai/docs/ai-sdk-ui/chatbot-tool-usage)). 
- so i checked if we can add the stream using openai sdk, and in this PR i was able to do so. see vid reference:

https://github.com/user-attachments/assets/3ff042c6-de0d-4602-b271-e9468a7e2fb7

