### PR TITLE
fix(DEV-4863): make oldowan cli accessible by npx

### DIFF
--- a/packages/oldowan/package.json
+++ b/packages/oldowan/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@elite-agents/oldowan",
   "module": "src/index.ts",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "type": "module",
   "bin": {
     "oldowan": "./dist/cli.js"
   },
   "scripts": {
     "build": "bun build ./src/index.ts ./src/cli.ts --outdir ./dist --target bun && bun run build:types",
-    "build:all": "bun install && bun build ./src/index.ts ./src/cli.ts --outdir ./dist --target node && bun run build:types",
+    "build:node": "bun build ./src/index.ts ./src/cli.ts --outdir ./dist --target node && bun run build:types",
     "dev": "bun run build:all --watch",
     "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
-    "publish": "bun run build && npm publish --access=public",
+    "publish:package": "bun run build:node && npm publish --access=public",
     "publish:dry": "bun run build && npm pack --dry-run"
   },
   "devDependencies": {


### PR DESCRIPTION
to run cli:

`npx @elite-agents/oldowan create my-oldowan`

Things to note:
- build must target node, otherwise an `TypeError: __require is not a function` error will occur when executing using npx.
- changed the package.json "publish" script name to "publish:package" to prevent the publishing from occurring twice which was the case before since 
   > "When npm executes npm publish, it automatically runs the publish script as a pre-publish step".