### PR TITLE
build(DEV-4991): export SSEClientTransport class from machina-habilis

### DIFF
--- a/packages/machina-habilis/package.json
+++ b/packages/machina-habilis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elite-agents/machina-habilis",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "module": "src/index.ts",
   "type": "module",
   "scripts": {
@@ -8,7 +8,7 @@
     "build:all": "bun install && bun build ./src/index.ts --outdir ./dist && bun run build:types",
     "dev": "bun run build:all --watch",
     "build:types": "tsc --emitDeclarationOnly",
-    "publish": "npm publish --access=public"
+    "publish:package": "bun run build && npm publish --access=public"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/packages/machina-habilis/src/index.ts
+++ b/packages/machina-habilis/src/index.ts
@@ -3,3 +3,4 @@ export * from './machina';
 export * from './persona';
 export * from './types';
 export * from './constants';
+export * from './SSEClientTransport';


### PR DESCRIPTION
export SSEClientTransport and update publish script to prevent publishing of machina-habilis from occurring twice. 