### PR TITLE
feat(DEV-5029): use latest openai response api

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,13 +57,11 @@
       "name": "@elite-agents/machina-habilis",
       "version": "0.1.5",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.36.3",
-        "@elite-agents/machina-habilis": "0.1.5",
         "@elite-agents/oldowan": "*",
         "@solana/web3.js": "^1.98.0",
         "hono": "^4.7.5",
         "nanoid": "^5.0.9",
-        "openai": "^4.83.0",
+        "openai": "^4.90.0",
         "zod": "^3.24.2",
       },
       "devDependencies": {
@@ -73,7 +71,7 @@
     },
     "packages/oldowan": {
       "name": "@elite-agents/oldowan",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "bin": {
         "oldowan": "./dist/cli.js",
       },
@@ -102,8 +100,6 @@
     "@ai-sdk/react": ["@ai-sdk/react@1.2.1", "", { "dependencies": { "@ai-sdk/provider-utils": "2.2.1", "@ai-sdk/ui-utils": "1.2.1", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["zod"] }, "sha512-ZC1GlQ/NRMMAl66nbcqiKmn2DrJb7faDQxvdE8W0aUZYNsGCwFLiNcbGkV7i6Y3VM0nFq9p8joOqAs1cv7zt9g=="],
 
     "@ai-sdk/ui-utils": ["@ai-sdk/ui-utils@1.2.1", "", { "dependencies": { "@ai-sdk/provider": "1.1.0", "@ai-sdk/provider-utils": "2.2.1", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-BzvMbYm7LHBlbWuLlcG1jQh4eu14MGpz7L+wrGO1+F4oQ+O0fAjgUSNwPWGlZpKmg4NrcVq/QLmxiVJrx2R4Ew=="],
-
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.36.3", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-+c0mMLxL/17yFZ4P5+U6bTWiCSFZUKJddrv01ud2aFBWnTPLdRncYV76D3q1tqfnL7aCnhRtykFnoCFzvr4U3Q=="],
 
     "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@11.9.3", "", { "dependencies": { "@jsdevtools/ono": "^7.1.3", "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.0" } }, "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ=="],
 
@@ -493,7 +489,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "openai": ["openai@4.83.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-fmTsqud0uTtRKsPC7L8Lu55dkaTwYucqncDHzVvO64DKOpNTuiYwjbR/nVgpapXuYy8xSnhQQPUm+3jQaxICgw=="],
+    "openai": ["openai@4.90.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-YCuHMMycqtCg1B8G9ezkOF0j8UnBWD3Al/zYaelpuXwU1yhCEv+Y4n9G20MnyGy6cH4GsFwOMrgstQ+bgG1PtA=="],
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
@@ -639,9 +635,9 @@
 
     "@ai-sdk/provider-utils/nanoid": ["nanoid@3.3.8", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="],
 
-    "@elite-agents/machina-habilis/@types/bun": ["@types/bun@1.2.6", "", { "dependencies": { "bun-types": "1.2.6" } }, "sha512-fY9CAmTdJH1Llx7rugB0FpgWK2RKuHCs3g2cFDYXUutIy1QGiPQxKkGY8owhfZ4MXWNfxwIbQLChgH5gDsY7vw=="],
+    "@elite-agents/machina-habilis/@types/bun": ["@types/bun@1.2.8", "", { "dependencies": { "bun-types": "1.2.7" } }, "sha512-t8L1RvJVUghW5V+M/fL3Thbxcs0HwNsXsnTEBEfEVqGteiJToOlZ/fyOEaR1kZsNqnu+3XA4RI/qmnX4w6+S+w=="],
 
-    "@elite-agents/oldowan/@types/bun": ["@types/bun@1.2.6", "", { "dependencies": { "bun-types": "1.2.6" } }, "sha512-fY9CAmTdJH1Llx7rugB0FpgWK2RKuHCs3g2cFDYXUutIy1QGiPQxKkGY8owhfZ4MXWNfxwIbQLChgH5gDsY7vw=="],
+    "@elite-agents/oldowan/@types/bun": ["@types/bun@1.2.8", "", { "dependencies": { "bun-types": "1.2.7" } }, "sha512-t8L1RvJVUghW5V+M/fL3Thbxcs0HwNsXsnTEBEfEVqGteiJToOlZ/fyOEaR1kZsNqnu+3XA4RI/qmnX4w6+S+w=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@3.24.1", "", {}, "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A=="],
 
@@ -695,9 +691,9 @@
 
     "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
-    "@elite-agents/machina-habilis/@types/bun/bun-types": ["bun-types@1.2.6", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-FbCKyr5KDiPULUzN/nm5oqQs9nXCHD8dVc64BArxJadCvbNzAI6lUWGh9fSJZWeDIRD38ikceBU8Kj/Uh+53oQ=="],
+    "@elite-agents/machina-habilis/@types/bun/bun-types": ["bun-types@1.2.7", "", { "dependencies": { "@types/node": "*", "@types/ws": "*" } }, "sha512-P4hHhk7kjF99acXqKvltyuMQ2kf/rzIw3ylEDpCxDS9Xa0X0Yp/gJu/vDCucmWpiur5qJ0lwB2bWzOXa2GlHqA=="],
 
-    "@elite-agents/oldowan/@types/bun/bun-types": ["bun-types@1.2.6", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-FbCKyr5KDiPULUzN/nm5oqQs9nXCHD8dVc64BArxJadCvbNzAI6lUWGh9fSJZWeDIRD38ikceBU8Kj/Uh+53oQ=="],
+    "@elite-agents/oldowan/@types/bun/bun-types": ["bun-types@1.2.7", "", { "dependencies": { "@types/node": "*", "@types/ws": "*" } }, "sha512-P4hHhk7kjF99acXqKvltyuMQ2kf/rzIw3ylEDpCxDS9Xa0X0Yp/gJu/vDCucmWpiur5qJ0lwB2bWzOXa2GlHqA=="],
 
     "@solana/web3.js/bs58/base-x": ["base-x@3.0.10", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ=="],
 

--- a/packages/machina-habilis/package.json
+++ b/packages/machina-habilis/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@elite-agents/machina-habilis",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "module": "src/index.ts",
   "type": "module",
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir ./dist --external @anthropic-ai/sdk --external @solana/web3.js --external openai --external hono --external zod && bun run build:types",
+    "build": "bun build ./src/index.ts --outdir ./dist --external @solana/web3.js --external openai --external hono --external zod && bun run build:types",
     "build:all": "bun install && bun build ./src/index.ts --outdir ./dist && bun run build:types",
     "dev": "bun run build --watch",
     "build:types": "tsc --emitDeclarationOnly",
@@ -21,12 +21,11 @@
     "access": "public"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.36.3",
     "@elite-agents/oldowan": "*",
     "@solana/web3.js": "^1.98.0",
     "hono": "^4.7.5",
     "nanoid": "^5.0.9",
-    "openai": "^4.83.0",
+    "openai": "^4.90.0",
     "zod": "^3.24.2"
   },
   "main": "./dist/index.js",

--- a/packages/machina-habilis/src/mnemon.ts
+++ b/packages/machina-habilis/src/mnemon.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
-import { ZMessageLifecycle } from './types';
-import type { MemoryFunction, MemoryService, IMessageLifecycle } from './types';
+import { ZAgentPromptState } from './types';
+import type { MemoryFunction, MemoryService, IAgentPromptState } from './types';
 import { cors } from 'hono/cors';
 
 export class MnemonServer {
@@ -26,7 +26,7 @@ export class MnemonServer {
     this.app.post('/recall-memory', async (c) => {
       const lifecycle = await c.req.json();
 
-      const result = ZMessageLifecycle.safeParse(lifecycle);
+      const result = ZAgentPromptState.safeParse(lifecycle);
       if (!result.success) {
         return c.json(
           { error: 'Invalid lifecycle payload', details: result.error },
@@ -41,7 +41,7 @@ export class MnemonServer {
     this.app.post('/create-memory', async (c) => {
       const lifecycle = await c.req.json();
 
-      const result = ZMessageLifecycle.safeParse(lifecycle);
+      const result = ZAgentPromptState.safeParse(lifecycle);
       if (!result.success) {
         return c.json(
           { error: 'Invalid lifecycle payload', details: result.error },
@@ -62,7 +62,7 @@ export class MnemonClient implements MemoryService {
     this.baseUrl = baseUrl;
   }
 
-  async recallMemory(lifecycle: IMessageLifecycle): Promise<IMessageLifecycle> {
+  async recallMemory(lifecycle: IAgentPromptState): Promise<IAgentPromptState> {
     const response = await fetch(`${this.baseUrl}/recall-memory`, {
       method: 'POST',
       headers: {
@@ -82,7 +82,7 @@ export class MnemonClient implements MemoryService {
     return memory;
   }
 
-  async createMemory(lifecycle: IMessageLifecycle): Promise<IMessageLifecycle> {
+  async createMemory(lifecycle: IAgentPromptState): Promise<IAgentPromptState> {
     const response = await fetch(`${this.baseUrl}/create-memory`, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
The main change in this PR is the use of OpenAI's newest Responses API which keeps track of a `previous_response_id` so the state of the thread is remembered by the API instead of needing to use a memory service.

Now, a memory service is only needed to fetch long-term memory.

Also added the ability to pass in additional context from the client, such as a wallet/