### PR TITLE
feat(DEV-5078): create ability CLI for oldowan servers on Cloudflare worker

### DIFF
--- a/packages/oldowan/package.json
+++ b/packages/oldowan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elite-agents/oldowan",
   "module": "src/index.ts",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "bin": {
     "oldowan": "./dist/cli.js"


### PR DESCRIPTION
Creating a ability via the oldowan CLI will now create a template project that will be deployable as a Cloudflare Worker.

`npx @elite-agents/oldowan create <project-name>`

Upticked "@elite-agents/oldowan" to 0.2.4.  When this is approved and merged, I can publish the new package version.  

