### PR TITLE
feat(DEV-5198): add env var support and readme to oldowan create command

### DIFF
--- a/packages/oldowan/src/commands/create.ts
+++ b/packages/oldowan/src/commands/create.ts
@@ -11,9 +11,9 @@ const TEMPLATES = {
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "wrangler dev",
-    "start": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "dev": "wrangler --env dev dev",
+    "deploy:dev": "wrangler --env dev deploy",
+    "deploy:prod": "wrangler --env prod deploy",
     "inspect-mcp-server": "SERVER_PORT=9000 npx @modelcontextprotocol/inspector"
   },
   "dependencies": {
@@ -65,12 +65,12 @@ import { z } from 'zod';
 
 export const exampleTool = new OldowanTool({
   name: 'example',
-  description: 'An example tool that echoes input',
+  description: 'An example tool that echoes input with an environment variable',
   schema: {
     message: z.string().describe('Message to echo'),
   },
   async execute({ message }) {
-    return { message };
+    return { message, ENV_VAR: process.env.ENV_VAR };
   },
 });`,
 
@@ -93,10 +93,10 @@ export default server.honoServer;`,
   "name": "${name}",
   "main": "src/server.ts",
   "compatibility_date": "2025-03-27",
-  "compatibility_flags": ["nodejs_compat"],
+  "compatibility_flags": ["nodejs_compat", "nodejs_compat_populate_process_env"],
   "observability": {
     "enabled": true
-  }
+  },
   /**
 	 * Smart Placement
 	 * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement
@@ -114,7 +114,19 @@ export default server.honoServer;`,
 	 * Environment Variables
 	 * https://developers.cloudflare.com/workers/wrangler/configuration/#environment-variables
 	 */
-	// "vars": { "MY_VARIABLE": "production_value" },
+  "env": {
+    "dev": {
+      "vars": { 
+        "ENV_VAR": "development" 
+      }
+    },
+    "prod": {
+      "vars": { 
+        "ENV_VAR": "production" 
+      }
+    }
+  },
+
 	/**
 	 * Note: Use secrets to store sensitive data.
 	 * https://developers.cloudflare.com/workers/configuration/secrets/
@@ -138,6 +150,57 @@ dist/
 .env
 .DS_Store
 .wrangler`,
+
+  'README.md': () => `# Oldowan MCP Server on Cloudflare Workers
+
+Welcome! This template helps you quickly bootstrap your own Oldowan MCP (Model Context Protocol) server using Cloudflare Workers and Wrangler.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js (v18 or later recommended)
+- Wrangler CLI (npm install -g wrangler)
+- A Cloudflare account
+
+### Configuration
+
+The wrangler.jsonc file is already prepared for you. You'll need to:
+
+1. Get your Cloudflare account ID from the Cloudflare dashboard
+2. Set your account ID in the wrangler.jsonc file or via environment variables
+3. Optionally customize other settings in the wrangler.jsonc file
+
+### Development and Deployment
+
+Install dependencies:
+\`\`\`
+npm install
+\`\`\`
+
+Start a local development server:
+\`\`\`
+npm run dev
+\`\`\`
+
+Deploy to Cloudflare Workers:
+\`\`\`
+npm run deploy:dev   # For development environment
+npm run deploy:prod  # For production environment
+\`\`\`
+
+## Customizing Your MCP Server
+
+- Edit src/tools/example.ts to create your own MCP tools
+- Add new tools to src/server.ts
+- Customize the server configuration as needed
+
+## Resources
+
+- Cloudflare Workers: https://developers.cloudflare.com/workers/
+- Wrangler CLI: https://developers.cloudflare.com/workers/wrangler/
+
+`,
 
 };
 
@@ -165,7 +228,8 @@ To get started:
   npm run dev
 
 To deploy to Cloudflare Workers (requires Cloudflare account https://www.cloudflare.com/plans/developer-platform/):
-  npm run deploy
+  npm run deploy:dev   # For development environment
+  npm run deploy:prod  # For production environment
     `);
   } catch (error) {
     console.error('Error creating project:', error);


### PR DESCRIPTION
@elite-agents/oldowan `create` cli will now generate a starter project that supports populating the `process.env` ("nodejs_compat_populate_process_env") object.  The generated example tool will return an example env var in its output.  

A generated README has also been added to guide users on how to get started.  