### PR TITLE
feat(DEV-5235): use serverUrl as toolId prefix and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,5 @@ dist
 
 # Files ending in .db
 *.db
+
+junit.xml

--- a/packages/machina-habilis/src/habilis.ts
+++ b/packages/machina-habilis/src/habilis.ts
@@ -2,6 +2,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { TextContent } from '@modelcontextprotocol/sdk/types.js';
 import {
   deriveToolUniqueName,
+  extractPaymentDetailsFromDescription,
   normalizeToolName,
   type OldowanToolDefinition,
   type ToolAuthArg,
@@ -99,11 +100,11 @@ export class HabilisServer {
         version: '1.0.0',
       });
 
-      console.log('Connecting to MCP server:', url);
+      console.debug('Connecting to MCP server:', url);
 
       try {
         await client.connect(new HTTPClientTransport(new URL(url)));
-        console.log('Connected to MCP server:', url);
+        console.debug('Connected to MCP server:', url);
       } catch (error) {
         let retries = 0;
         const maxRetries = 3;
@@ -154,12 +155,17 @@ export class HabilisServer {
       }
 
       const toolsAdded = tools.map((tool) => {
-        const derivedToolName = deriveToolUniqueName(serverName, tool.name);
+        const derivedToolName = deriveToolUniqueName(url, tool.name);
+        const paymentDetails = extractPaymentDetailsFromDescription(
+          tool.description ?? '',
+        );
+
         const oldowanToolDefinition: OldowanToolDefinition = {
           ...tool,
           id: derivedToolName,
           name: normalizeToolName(tool.name),
           serverUrl: url,
+          paymentDetails,
         };
 
         return oldowanToolDefinition;

--- a/packages/oldowan/src/oldowan-server.ts
+++ b/packages/oldowan/src/oldowan-server.ts
@@ -31,9 +31,8 @@ export class OldowanServer implements IOldowanServer {
     opts.tools.forEach((tool) => {
       const description = tool.paymentDetails
         ? tool.description +
-          '\n\n<Payment Details>' +
-          generatePaymentDescription(tool.paymentDetails) +
-          '</Payment Details>'
+          '\n\n' +
+          generatePaymentDescription(tool.paymentDetails)
         : tool.description;
 
       const schema = tool.paymentDetails


### PR DESCRIPTION
This pull request introduces enhancements to payment details handling, refactors logging for better debugging, and updates test cases to reflect the new functionality. The most significant changes include adding a utility to extract payment details from descriptions, updating tool creation logic to incorporate payment details, and improving test coverage for these updates.

### Enhancements to Payment Details Handling:
* Added `extractPaymentDetailsFromDescription` utility to parse payment details from tagged descriptions, enabling structured extraction of payment information. (`packages/oldowan/src/utils.ts`, [packages/oldowan/src/utils.tsL57-R185](diffhunk://#diff-613e637f39c1748d3f7317fcac2965befff9d35412b764021155ab49bc5a1d8dL57-R185))
* Updated `generatePaymentDescription` to include XML-like tags for structured formatting of payment details. (`packages/oldowan/src/utils.ts`, [packages/oldowan/src/utils.tsL57-R185](diffhunk://#diff-613e637f39c1748d3f7317fcac2965befff9d35412b764021155ab49bc5a1d8dL57-R185))
* Modified `OldowanServer` to use the updated `generatePaymentDescription` format, removing redundant tags. (`packages/oldowan/src/oldowan-server.ts`, [packages/oldowan/src/oldowan-server.tsL34-R35](diffhunk://#diff-47714dd347adc365f93bd9bdc89a8873e44dd1a13e013c13614ee1ac37421192L34-R35))

### Refactoring and Code Improvements:
* Replaced `console.log` calls with `console.debug` for more appropriate logging levels in `HabilisServer`. (`packages/machina-habilis/src/habilis.ts`, [packages/machina-habilis/src/habilis.tsL102-R107](diffhunk://#diff-a53babb2ade168f9fc2b2f2845378f07ce402e440824ee1814f45850abadbfcbL102-R107))
* Updated `deriveToolUniqueName` to use `url` instead of `serverName` and integrated `extractPaymentDetailsFromDescription` into tool creation logic. (`packages/machina-habilis/src/habilis.ts`, [packages/machina-habilis/src/habilis.tsL157-R168](diffhunk://#diff-a53babb2ade168f9fc2b2f2845378f07ce402e440824ee1814f45850abadbfcbL157-R168))

### Test Updates and Coverage:
* Added a new test case to ensure `OldowanTool` creation fails if the schema includes a reserved `auth` field. (`packages/machina-habilis/src/tests/agent.e2e.test.ts`, [packages/machina-habilis/src/tests/agent.e2e.test.tsL115-R142](diffhunk://#diff-c3bc8709a07aaabdb8c2500c78b222876147d0c1b7327965ba2e8c61215e50c6L115-R142))
* Refactored end-to-end tests to use `HabilisServer.addMCPServer`, simplifying tool setup and validating payment details. (`packages/machina-habilis/src/tests/agent.e2e.test.ts`, [[1]](diffhunk://#diff-c3bc8709a07aaabdb8c2500c78b222876147d0c1b7327965ba2e8c61215e50c6L40-R61) [[2]](diffhunk://#diff-c3bc8709a07aaabdb8c2500c78b222876147d0c1b7327965ba2e8c61215e50c6R79-R110)
* Introduced a mapping mechanism in tests to differentiate between paid and free tools, ensuring accurate validation. (`packages/machina-habilis/src/tests/agent.e2e.test.ts`, [packages/machina-habilis/src/tests/agent.e2e.test.tsR79-R110](diffhunk://#diff-c3bc8709a07aaabdb8c2500c78b222876147d0c1b7327965ba2e8c61215e50c6R79-R110))