### PR TITLE
fix: do not append `null` to all optional inputs

### DIFF
--- a/packages/machina-habilis/src/llm.ts
+++ b/packages/machina-habilis/src/llm.ts
@@ -149,22 +149,13 @@ export async function promptLLM(
                 const inputSchema = tool.inputSchema as JSONSchema7;
                 const properties = inputSchema.properties;
 
-                const required = inputSchema.required ?? [];
-
-                // Make non-required properties nullable
                 if (properties) {
                   Object.keys(properties).forEach((propKey) => {
                     const prop = properties[propKey] as JSONSchema7;
-                    if (
-                      !required.includes(propKey) &&
-                      prop.type !== 'null' &&
-                      prop.type?.[0] !== 'null' &&
-                      !prop.type?.includes?.('null')
-                    ) {
-                      prop.type = [
-                        prop.type as JSONSchema7TypeName,
-                        'null',
-                      ].filter(Boolean) as JSONSchema7TypeName[];
+                    if (!prop.type) {
+                      // if there is no prop type, make it null
+                      // this happens when the property is any()
+                      prop.type = ['null'];
                     }
                   });
                 }

--- a/packages/oldowan/package.json
+++ b/packages/oldowan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elite-agents/oldowan",
-  "module": "src/index.ts",
+  "module": "./src/index.ts",
   "version": "0.4.0",
   "type": "module",
   "bin": {

--- a/packages/oldowan/src/types.ts
+++ b/packages/oldowan/src/types.ts
@@ -58,24 +58,33 @@ export type IEndpointDefinition = z.infer<typeof ZEndpointDefinition>;
 export type OpenAPIParameter = z.infer<typeof ZOpenAPIParameter>;
 export type OpenAPIRequestBody = z.infer<typeof ZOpenAPIRequestBody>;
 
-export type PaymentDetails =
-  | {
-      type: 'token-gated';
-      mint: string; // SPL token mint address
-      amountUi: number; // Amount in UI decimals
-      description?: string;
-    }
-  | {
-      type: 'subscription';
-      planId: string; // Subscription plan identifier
-      description?: string;
-    }
-  | {
-      type: 'credit';
-      amount: number; // Number of credits required
-      creditId: string; // Credit type identifier
-      description?: string;
-    };
+export const TokenGatedPaymentDetailsSchema = z.object({
+  type: z.literal('token-gated'),
+  mint: z.string(),
+  amountUi: z.number(),
+  description: z.string().optional(),
+});
+
+export const SubscriptionPaymentDetailsSchema = z.object({
+  type: z.literal('subscription'),
+  planId: z.string(),
+  description: z.string().optional(),
+});
+
+export const CreditPaymentDetailsSchema = z.object({
+  type: z.literal('credit'),
+  amount: z.number(),
+  creditId: z.string(),
+  description: z.string().optional(),
+});
+
+export const PaymentDetailsSchema = z.discriminatedUnion('type', [
+  TokenGatedPaymentDetailsSchema,
+  SubscriptionPaymentDetailsSchema,
+  CreditPaymentDetailsSchema,
+]);
+
+export type PaymentDetails = z.infer<typeof PaymentDetailsSchema>;
 
 export type OldowanToolDefinition = Tool & {
   id: string;


### PR DESCRIPTION
This pull request introduces several updates across multiple files, focusing on improving type safety, adding new test cases, and refining the schema definitions. The key changes include replacing a custom type with a Zod schema for `PaymentDetails`, enhancing the handling of optional properties in JSON schemas, and adding a new end-to-end test for tools with optional parameters.

### Schema and Type Improvements:
* Replaced the `PaymentDetails` custom type with a Zod discriminated union schema for better type safety and validation. (`packages/oldowan/src/types.ts`)

### JSON Schema Handling:
* Updated the `promptLLM` function to handle cases where a property has no defined type by defaulting it to `null`. This improves compatibility with schemas where properties are defined as `any()`. (`packages/machina-habilis/src/llm.ts`)

### Testing Enhancements:
* Added a new end-to-end test to verify that tools can be called with optional parameters, ensuring proper handling of optional fields in tool execution. (`packages/machina-habilis/src/tests/agent.e2e.test.ts`)
* Enhanced an existing test to check that tool outputs do not contain errors, improving test coverage for function call outputs. (`packages/machina-habilis/src/tests/agent.e2e.test.ts`)

### Minor Fixes:
* Adjusted the `module` field in the `package.json` file of the `oldowan` package to include a leading `./`, ensuring compatibility with module resolution. (`packages/oldowan/package.json`)
* Removed unused type imports in the `agent.e2e.test.ts` file to clean up the code. (`packages/machina-habilis/src/tests/agent.e2e.test.ts`)