### PR TITLE
feat: update machina-agent to take base64 string as keypair to encaps…

### DIFF
--- a/packages/machina-habilis/package.json
+++ b/packages/machina-habilis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elite-agents/machina-habilis",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "module": "src/index.ts",
   "type": "module",
   "scripts": {
@@ -11,9 +11,13 @@
     "publish:package": "bun run build && npm publish --access=public"
   },
   "devDependencies": {
+    "@elite-agents/oldowan": "workspace:*",
     "@types/bun": "latest",
     "typescript": "^5.0.0"
   },
+  "bundledDependencies": [
+    "@elite-agents/oldowan"
+  ],
   "files": [
     "dist"
   ],
@@ -21,7 +25,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@elite-agents/oldowan": "workspace:*",
     "@solana/kit": "^2.1.0",
     "@types/json-schema": "^7.0.15",
     "hono": "^4.7.5",

--- a/packages/oldowan/package.json
+++ b/packages/oldowan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elite-agents/oldowan",
   "module": "./src/index.ts",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "bin": {
     "oldowan": "./dist/cli.js"

--- a/packages/oldowan/src/crypto.ts
+++ b/packages/oldowan/src/crypto.ts
@@ -1,0 +1,36 @@
+/**
+ * Ed25519 algorithm identifier for Web Crypto API calls.
+ * Use this object with crypto.subtle.generateKey and importKey functions.
+ */
+export const ED25519_ALGORITHM_IDENTIFIER = Object.freeze({ name: 'Ed25519' });
+
+/**
+ * Generates a new Ed25519 keypair and exports raw key bytes.
+ *
+ * Exports the public key in 'raw' format and the private key in 'pkcs8', slices the private key to 32 bytes,
+ * then concatenates public||private into a single Buffer.
+ *
+ * @returns A Buffer containing 64 bytes: [publicKey (32 bytes) || privateKey (32 bytes)].
+ */
+export const generateKeypairRawBytes = async () => {
+  const keypair = (await crypto.subtle.generateKey(
+    ED25519_ALGORITHM_IDENTIFIER, //
+    true,
+    ['sign', 'verify'],
+  )) as CryptoKeyPair;
+
+  const publicKeyBytes = await crypto.subtle.exportKey(
+    'raw',
+    keypair.publicKey,
+  );
+  const pkcs8Bytes = await crypto.subtle.exportKey('pkcs8', keypair.privateKey);
+  const privateKeyBytes = pkcs8Bytes.slice(16);
+
+  // concatenate public and private key bytes
+  const keypairBytes = Buffer.concat([
+    new Uint8Array(privateKeyBytes),
+    new Uint8Array(publicKeyBytes),
+  ]);
+
+  return keypairBytes;
+};

--- a/packages/oldowan/src/index.ts
+++ b/packages/oldowan/src/index.ts
@@ -5,3 +5,4 @@ export * from './utils';
 export * from './rest-wrapper-server';
 export * from './rest-wrapper-tool';
 export * from './openapi-utils';
+export * from './crypto';

--- a/packages/oldowan/src/oldowan-tool.ts
+++ b/packages/oldowan/src/oldowan-tool.ts
@@ -1,12 +1,13 @@
 import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
-import type { PaymentDetails, ToolAuthArg } from './types';
+import { type PaymentDetails, type ToolAuthArg } from './types';
 import {
   verifySignature,
   type SignatureBytes,
   getBase58Encoder,
 } from '@solana/kit';
 import { generateDeterministicPayloadForSigning } from './utils';
+import { ED25519_ALGORITHM_IDENTIFIER } from './crypto';
 
 export class OldowanTool<T extends z.ZodRawShape> {
   name: string;
@@ -76,7 +77,7 @@ export class OldowanTool<T extends z.ZodRawShape> {
         const publicKey = await crypto.subtle.importKey(
           'raw',
           getBase58Encoder().encode(publicKeyBase58),
-          { name: 'Ed25519' },
+          ED25519_ALGORITHM_IDENTIFIER,
           true,
           ['verify'],
         );


### PR DESCRIPTION
…ulate crypto implementation

### Motivation

As I was updating the machina-habilis package on the platform, I realized that the DX was pretty bad when you have to import the exact implementation of `CryptoKeypair` (which has now recently been changed to use `solana/kit` instead of `solana/web3.js`, mainly for the convenience of the `signBytes` method.

Instead, this logic should be encapsulated, and the only thing that matters is the raw keypair in byte-format.

This PR addresses this. Test was added.

## Copilot Summary:

This pull request introduces significant updates to the `machina-habilis` and `oldowan` packages, focusing on refactoring keypair handling, enhancing cryptographic utilities, and improving test coverage. The most notable changes include replacing the keypair object with a Base64URL-encoded string in `MachinaAgent`, adding a utility to generate raw Ed25519 keypair bytes, and updating tests to reflect these changes.

### Keypair Handling Refactor (`machina-habilis`):

* Replaced the `CryptoKeyPair` object with a `keypairBase64Url` string in the `MachinaAgent` class. Added a lazy initialization method to decode and import the keypair when needed. This simplifies keypair storage and usage. [[1]](diffhunk://#diff-a0702c9d64de58431063e42ab45db0220ab8291b17b7b569aee8bf1937f7fa01L17-R48) [[2]](diffhunk://#diff-a0702c9d64de58431063e42ab45db0220ab8291b17b7b569aee8bf1937f7fa01L55-R86) [[3]](diffhunk://#diff-a0702c9d64de58431063e42ab45db0220ab8291b17b7b569aee8bf1937f7fa01R97-R113) [[4]](diffhunk://#diff-a0702c9d64de58431063e42ab45db0220ab8291b17b7b569aee8bf1937f7fa01L90-R136) [[5]](diffhunk://#diff-a0702c9d64de58431063e42ab45db0220ab8291b17b7b569aee8bf1937f7fa01R206-R211)
* Updated the `message` method and signing logic to use the new keypair handling method. [[1]](diffhunk://#diff-a0702c9d64de58431063e42ab45db0220ab8291b17b7b569aee8bf1937f7fa01R206-R211) [[2]](diffhunk://#diff-a0702c9d64de58431063e42ab45db0220ab8291b17b7b569aee8bf1937f7fa01L90-R136)

### Cryptographic Enhancements (`oldowan`):

* Added a new utility function, `generateKeypairRawBytes`, to generate Ed25519 keypairs and export raw key bytes. This utility concatenates public and private key bytes into a single buffer for simplified transport.
* Exported `ED25519_ALGORITHM_IDENTIFIER` for consistent use of the Ed25519 algorithm in Web Crypto API calls.
* Updated `OldowanTool` to use the new `ED25519_ALGORITHM_IDENTIFIER` for key import operations.

### Testing Improvements:

* Updated end-to-end tests for `MachinaAgent` to use the new `keypairBase64Url` approach. Added a test case to validate error handling for invalid keypairs. [[1]](diffhunk://#diff-c3bc8709a07aaabdb8c2500c78b222876147d0c1b7327965ba2e8c61215e50c6R64-R72) [[2]](diffhunk://#diff-c3bc8709a07aaabdb8c2500c78b222876147d0c1b7327965ba2e8c61215e50c6L187-R194) [[3]](diffhunk://#diff-c3bc8709a07aaabdb8c2500c78b222876147d0c1b7327965ba2e8c61215e50c6R220-R238)
* Added `generateKeypairRawBytes` to tests to generate test keypairs dynamically.

### Dependency and Version Updates:

* Updated `machina-habilis` package version to `0.3.3`. Added `@elite-agents/oldowan` as a bundled dependency. [[1]](diffhunk://#diff-c2b5f3dae12c8ef61f4cb79972307c8be6484715f25e0546780099c5804d468eL3-R3) [[2]](diffhunk://#diff-c2b5f3dae12c8ef61f4cb79972307c8be6484715f25e0546780099c5804d468eR14-L24)
* Updated `oldowan` package version to `0.4.1`.

These changes improve the modularity, security, and testability of the `machina-habilis` and `oldowan` packages while maintaining backward compatibility with existing functionality.