### PR TITLE
feat(DEV-5334): add blink directive handling and custom system prompt…

### DIFF
--- a/.changeset/fine-rules-serve.md
+++ b/.changeset/fine-rules-serve.md
@@ -1,0 +1,5 @@
+---
+'@elite-agents/machina-habilis': minor
+---
+
+update system prompt to include blink instructions and also provide a way to pass in additional system prompt

--- a/packages/machina-habilis/src/llm.ts
+++ b/packages/machina-habilis/src/llm.ts
@@ -57,6 +57,20 @@ It's *very* important that if you do not know something, then you don't make som
 - If a tool fails, see if you can fix it or use another tool to accomplish the task
 - If you can't fix it, then see if the user can help you fix it by providing more information
 
+# Tool Use Return Guidelines
+
+⚠️ CRITICAL INSTRUCTION ⚠️
+From time to time a tool returns a string in a special ::blink directive that must be displayed EXACTLY as-is with NO CHANGES.
+
+- Include the output on its own line
+- Do NOT wrap it in brackets, links, or any formatting
+- Do NOT modify any values in the output
+- Do NOT add explanatory text before or after the output
+
+FAILURE TO FOLLOW THESE INSTRUCTIONS WILL CAUSE THE TRANSACTION TO FAIL.
+
+------------
+
 Remember: You are not just processing queries - you are embodying a specific identity with consistent traits, memories, and capabilities.
 `;
 
@@ -96,6 +110,14 @@ function createInstructionsPrompt(lifecycle: IAgentPromptState): string {
   <Your Identity>
   ${lifecycle.identityPrompt}
   </Your Identity>
+
+  ${
+    lifecycle.additionalSystemPrompt
+      ? `<Additional System Prompt>
+  ${lifecycle.additionalSystemPrompt}
+  </Additional System Prompt>`
+      : ''
+  }
   `;
 }
 

--- a/packages/machina-habilis/src/machina.ts
+++ b/packages/machina-habilis/src/machina.ts
@@ -199,6 +199,7 @@ export class MachinaAgent {
       streamTextHandler?: (text: string) => void;
       previousResponseId?: string;
       additionalContext?: Map<string, string>;
+      additionalSystemPrompt?: string;
     },
   ): Promise<IAgentPromptState> {
     const agentPubkey = await getAddressFromPublicKey(
@@ -224,6 +225,7 @@ export class MachinaAgent {
       output: '',
       actionsLog: [],
       previousResponseId: opts?.previousResponseId,
+      additionalSystemPrompt: opts?.additionalSystemPrompt,
     };
 
     const tools = Array.from(this.abilityMap.values()).map((tool) => ({

--- a/packages/machina-habilis/src/types.ts
+++ b/packages/machina-habilis/src/types.ts
@@ -40,6 +40,7 @@ export const ZAgentPromptState = z.object({
   output: z.string().default(''),
   actionsLog: z.array(z.string()).default([]),
   previousResponseId: z.string().optional(),
+  additionalSystemPrompt: z.string().optional(),
 });
 
 export const ZModelSettings = z.object({


### PR DESCRIPTION
This pull request introduces updates to the `machina-habilis` package to enhance system prompt handling and enforce stricter guidelines for tool output formatting. Key changes include adding support for an `additionalSystemPrompt`, updating the system prompt structure, and introducing critical instructions for handling tool output.

### Updates to system prompt handling:

* [`.changeset/fine-rules-serve.md`](diffhunk://#diff-4e0c59fad9c415b4e4935b5ed4a62b342cc715346a25093cf6101e1ce612fd5eR1-R5): Updated the system prompt to include blink instructions and added support for passing in an `additionalSystemPrompt`.
* [`packages/machina-habilis/src/llm.ts`](diffhunk://#diff-61fb744196fc786ee6d4fcdcab3e7c274ae55ce19618dd04ff47d7a52565fb03R113-R120): Modified the `createInstructionsPrompt` function to include the `additionalSystemPrompt` in the generated prompt if provided.
* [`packages/machina-habilis/src/machina.ts`](diffhunk://#diff-a0702c9d64de58431063e42ab45db0220ab8291b17b7b569aee8bf1937f7fa01R202): Added an `additionalSystemPrompt` property to the `MachinaAgent` options and ensured it is included in the agent's prompt state. [[1]](diffhunk://#diff-a0702c9d64de58431063e42ab45db0220ab8291b17b7b569aee8bf1937f7fa01R202) [[2]](diffhunk://#diff-a0702c9d64de58431063e42ab45db0220ab8291b17b7b569aee8bf1937f7fa01R228)
* [`packages/machina-habilis/src/types.ts`](diffhunk://#diff-c0489de3bcfb5559bb76a827e4b113d05d89424d56ff7941418a9fd24c2991f2R43): Updated the `ZAgentPromptState` schema to include an optional `additionalSystemPrompt` field.

### Tool output formatting guidelines:

* [`packages/machina-habilis/src/llm.ts`](diffhunk://#diff-61fb744196fc786ee6d4fcdcab3e7c274ae55ce19618dd04ff47d7a52565fb03R60-R73): Added critical instructions for handling tool outputs with the `::blink` directive to ensure they are displayed exactly as-is, with no modifications or formatting.… support