### PR TITLE
x402 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Build for release
-        run: bun build:release
+        run: bun run build
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/build-script.ts
+++ b/build-script.ts
@@ -1,0 +1,19 @@
+import type { BuildConfig } from 'bun';
+
+export async function build(config: BuildConfig) {
+  const startTime = Date.now();
+
+  const buildResult = await Bun.build(config);
+
+  if (buildResult.success) {
+    console.log(`Build completed in ${Date.now() - startTime}ms`);
+    buildResult.outputs.forEach(async (output) => {
+      const { size } = await Bun.file(output.path).stat();
+      console.log(
+        `Wrote ${output.path.replace(process.cwd() + '/', '')} (${(size / 1024).toFixed(2)} kb)`,
+      );
+    });
+  } else {
+    console.error(`Build failed in ${Date.now() - startTime}ms`);
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "devDependencies": {
         "@changesets/cli": "^2.29.2",
         "@types/bun": "latest",
+        "bun-plugin-dts": "^0.3.0",
         "prettier": "^3.5.0",
         "typescript": "^5.0.0",
       },
@@ -43,10 +44,10 @@
       "name": "@elite-agents/machina-habilis",
       "version": "0.4.0",
       "dependencies": {
+        "@elite-agents/auth": "workspace:*",
         "@solana/kit": "^2.1.0",
         "@types/json-schema": "^7.0.15",
         "hono": "^4.7.5",
-        "jose": "^6.0.11",
         "nanoid": "^5.0.9",
         "openai": "^4.90.0",
         "zod": "^3.24.2",
@@ -75,6 +76,7 @@
       },
       "devDependencies": {
         "@changesets/cli": "^2.29.2",
+        "@elite-agents/auth": "workspace:*",
         "@types/bun": "latest",
       },
       "peerDependencies": {
@@ -285,6 +287,8 @@
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
@@ -309,6 +313,8 @@
 
     "bufferutil": ["bufferutil@4.0.9", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw=="],
 
+    "bun-plugin-dts": ["bun-plugin-dts@0.3.0", "", { "dependencies": { "common-path-prefix": "^3.0.0", "dts-bundle-generator": "^9.5.1", "get-tsconfig": "^4.8.1" } }, "sha512-QpiAOKfPcdOToxySOqRY8FwL+brTvyXEHWzrSCRKt4Pv7Z4pnUrhK9tFtM7Ndm7ED09B/0cGXnHJKqmekr/ERw=="],
+
     "bun-types": ["bun-types@1.2.2", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-RCbMH5elr9gjgDGDhkTTugA21XtJAy/9jkKe/G3WR2q17VPGhcquf9Sir6uay9iW+7P/BV0CAHA1XlHXMAVKHg=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
@@ -319,9 +325,17 @@
 
     "ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+
+    "common-path-prefix": ["common-path-prefix@3.0.0", "", {}, "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
@@ -337,6 +351,10 @@
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
+    "dts-bundle-generator": ["dts-bundle-generator@9.5.1", "", { "dependencies": { "typescript": ">=5.0.2", "yargs": "^17.6.0" }, "bin": { "dts-bundle-generator": "dist/bin/dts-bundle-generator.js" } }, "sha512-DxpJOb2FNnEyOzMkG11sxO2dmxPjthoVWxfKqWYJ/bI/rT1rvTMktF5EKjAYrRZu6Z6t3NhOUZ0sZ5ZXevOfbA=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
     "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
@@ -344,6 +362,8 @@
     "es6-promise": ["es6-promise@4.2.8", "", {}, "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="],
 
     "es6-promisify": ["es6-promisify@5.0.0", "", { "dependencies": { "es6-promise": "^4.0.3" } }, "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
@@ -381,6 +401,10 @@
 
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-tsconfig": ["get-tsconfig@4.10.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ=="],
+
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
@@ -404,6 +428,8 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
@@ -495,7 +521,11 @@
 
     "regenerator-runtime": ["regenerator-runtime@0.14.1", "", {}, "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="],
 
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
@@ -530,6 +560,8 @@
     "stream-chain": ["stream-chain@2.2.5", "", {}, "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA=="],
 
     "stream-json": ["stream-json@1.9.1", "", { "dependencies": { "stream-chain": "^2.2.5" } }, "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -571,9 +603,17 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
     "yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -26,13 +26,27 @@
         "@types/bun": "latest",
       },
     },
+    "packages/auth": {
+      "name": "@elite-agents/auth",
+      "version": "0.1.0",
+      "dependencies": {
+        "bs58": "^6.0.0",
+        "jose": "^6.0.11",
+      },
+      "devDependencies": {
+        "@changesets/cli": "^2.29.2",
+        "@types/bun": "latest",
+        "typescript": "^5.0.0",
+      },
+    },
     "packages/machina-habilis": {
       "name": "@elite-agents/machina-habilis",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "dependencies": {
         "@solana/kit": "^2.1.0",
         "@types/json-schema": "^7.0.15",
         "hono": "^4.7.5",
+        "jose": "^6.0.11",
         "nanoid": "^5.0.9",
         "openai": "^4.90.0",
         "zod": "^3.24.2",
@@ -46,7 +60,7 @@
     },
     "packages/oldowan": {
       "name": "@elite-agents/oldowan",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "bin": {
         "oldowan": "./dist/cli.js",
       },
@@ -106,6 +120,8 @@
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20250424.0", "", {}, "sha512-tolHPBVlYSIZq5GWlGbbSqXg1P79u059YJ19cFULwRCF/KpElb9YDq/D9oPxqpw/niS9AvzVBCR5RCxsWv4LDQ=="],
+
+    "@elite-agents/auth": ["@elite-agents/auth@workspace:packages/auth"],
 
     "@elite-agents/machina-habilis": ["@elite-agents/machina-habilis@workspace:packages/machina-habilis"],
 
@@ -275,7 +291,7 @@
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
-    "base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+    "base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
@@ -287,7 +303,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+    "bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
@@ -402,6 +418,8 @@
     "isomorphic-ws": ["isomorphic-ws@4.0.1", "", { "peerDependencies": { "ws": "*" } }, "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="],
 
     "jayson": ["jayson@4.2.0", "", { "dependencies": { "@types/connect": "^3.4.33", "@types/node": "^12.12.54", "@types/ws": "^7.4.4", "commander": "^2.20.3", "delay": "^5.0.0", "es6-promisify": "^5.0.0", "eyes": "^0.1.8", "isomorphic-ws": "^4.0.1", "json-stringify-safe": "^5.0.1", "stream-json": "^1.9.1", "uuid": "^8.3.2", "ws": "^7.5.10" }, "bin": { "jayson": "bin/jayson.js" } }, "sha512-VfJ9t1YLwacIubLhONk0KFeosUBwstRWQ0IRT1KDjEjnVnSOVHC3uwugyV7L0c7R9lpVyrUGT2XWiBA1UTtpyg=="],
+
+    "jose": ["jose@6.0.11", "", {}, "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg=="],
 
     "js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
 
@@ -565,9 +583,11 @@
 
     "@changesets/write/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
-    "@elite-agents/machina-habilis/@types/bun": ["@types/bun@1.2.11", "", { "dependencies": { "bun-types": "1.2.11" } }, "sha512-ZLbbI91EmmGwlWTRWuV6J19IUiUC5YQ3TCEuSHI3usIP75kuoA8/0PVF+LTrbEnVc8JIhpElWOxv1ocI1fJBbw=="],
+    "@elite-agents/auth/@types/bun": ["@types/bun@1.2.15", "", { "dependencies": { "bun-types": "1.2.15" } }, "sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA=="],
 
-    "@elite-agents/oldowan/@types/bun": ["@types/bun@1.2.11", "", { "dependencies": { "bun-types": "1.2.11" } }, "sha512-ZLbbI91EmmGwlWTRWuV6J19IUiUC5YQ3TCEuSHI3usIP75kuoA8/0PVF+LTrbEnVc8JIhpElWOxv1ocI1fJBbw=="],
+    "@elite-agents/machina-habilis/@types/bun": ["@types/bun@1.2.15", "", { "dependencies": { "bun-types": "1.2.15" } }, "sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA=="],
+
+    "@elite-agents/oldowan/@types/bun": ["@types/bun@1.2.15", "", { "dependencies": { "bun-types": "1.2.15" } }, "sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
@@ -587,11 +607,15 @@
 
     "@solana/rpc-transport-http/undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
 
+    "@solana/web3.js/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
     "@types/connect/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
 
     "@types/node-fetch/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
 
     "@types/ws/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
+
+    "borsh/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "bun-types/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
 
@@ -609,9 +633,13 @@
 
     "solana-oldowan-server/@types/bun": ["@types/bun@1.2.10", "", { "dependencies": { "bun-types": "1.2.10" } }, "sha512-eilv6WFM3M0c9ztJt7/g80BDusK98z/FrFwseZgT4bXCq2vPhXD4z8R3oddmAn+R/Nmz9vBn4kweJKmGTZj+lg=="],
 
-    "@elite-agents/machina-habilis/@types/bun/bun-types": ["bun-types@1.2.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-dbkp5Lo8HDrXkLrONm6bk+yiiYQSntvFUzQp0v3pzTAsXk6FtgVMjdQ+lzFNVAmQFUkPQZ3WMZqH5tTo+Dp/IA=="],
+    "@elite-agents/auth/@types/bun/bun-types": ["bun-types@1.2.15", "", { "dependencies": { "@types/node": "*" } }, "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w=="],
 
-    "@elite-agents/oldowan/@types/bun/bun-types": ["bun-types@1.2.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-dbkp5Lo8HDrXkLrONm6bk+yiiYQSntvFUzQp0v3pzTAsXk6FtgVMjdQ+lzFNVAmQFUkPQZ3WMZqH5tTo+Dp/IA=="],
+    "@elite-agents/machina-habilis/@types/bun/bun-types": ["bun-types@1.2.15", "", { "dependencies": { "@types/node": "*" } }, "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w=="],
+
+    "@elite-agents/oldowan/@types/bun/bun-types": ["bun-types@1.2.15", "", { "dependencies": { "@types/node": "*" } }, "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w=="],
+
+    "@solana/web3.js/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "@types/connect/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
@@ -619,11 +647,15 @@
 
     "@types/ws/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
+    "borsh/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
     "bun-types/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
     "jayson/@types/ws/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
 
     "solana-oldowan-server/@types/bun/bun-types": ["bun-types@1.2.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-b5ITZMnVdf3m1gMvJHG+gIfeJHiQPJak0f7925Hxu6ZN5VKA8AGy4GZ4lM+Xkn6jtWxg5S3ldWvfmXdvnkp3GQ=="],
+
+    "@elite-agents/auth/@types/bun/bun-types/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
 
     "@elite-agents/machina-habilis/@types/bun/bun-types/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
 
@@ -632,6 +664,8 @@
     "jayson/@types/ws/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
     "solana-oldowan-server/@types/bun/bun-types/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
+
+    "@elite-agents/auth/@types/bun/bun-types/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
     "@elite-agents/machina-habilis/@types/bun/bun-types/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -83,8 +83,24 @@
         "typescript": "^5.0.0",
       },
     },
+    "packages/x402-solana": {
+      "name": "@elite-agents/x402-solana",
+      "version": "0.1.0",
+      "dependencies": {
+        "hono": "^4.7.11",
+        "x402": "^0.3.7",
+        "zod": "^3.25.58",
+      },
+      "devDependencies": {
+        "@changesets/cli": "^2.29.2",
+        "@types/bun": "latest",
+        "typescript": "^5.0.0",
+      },
+    },
   },
   "packages": {
+    "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.0", "", {}, "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="],
+
     "@babel/runtime": ["@babel/runtime@7.27.0", "", { "dependencies": { "regenerator-runtime": "^0.14.0" } }, "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw=="],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.0.12", "", { "dependencies": { "@changesets/config": "^3.1.1", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-EaET7As5CeuhTzvXTQCRZeBUcisoYPDDcXvgTE/2jmmypKp0RC7LxKj/yzqeh/1qFTZI7oDGFcL1PHRuQuketQ=="],
@@ -128,6 +144,8 @@
     "@elite-agents/machina-habilis": ["@elite-agents/machina-habilis@workspace:packages/machina-habilis"],
 
     "@elite-agents/oldowan": ["@elite-agents/oldowan@workspace:packages/oldowan"],
+
+    "@elite-agents/x402-solana": ["@elite-agents/x402-solana@workspace:packages/x402-solana"],
 
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
@@ -177,6 +195,8 @@
 
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.1", "", {}, "sha512-DnBpqkMOUGayNVKyTLlkM6ILmU/m/+VUxGkuQlPQVAcvreLz5jn1OlQnWd8uHKL/ZSiljpM12rjRhr51VtvJUQ=="],
 
+    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
     "@noble/curves": ["@noble/curves@1.9.0", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
@@ -188,6 +208,12 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@readme/openapi-schemas": ["@readme/openapi-schemas@3.1.0", "", {}, "sha512-9FC/6ho8uFa8fV50+FPy/ngWN53jaUu4GRXlAjcxIRrzhltJnpKkBG2Tp0IDraFJeWrOpk84RJ9EMEEYzaI1Bw=="],
+
+    "@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
+
+    "@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
 
     "@solana/accounts": ["@solana/accounts@2.1.0", "", { "dependencies": { "@solana/addresses": "2.1.0", "@solana/codecs-core": "2.1.0", "@solana/codecs-strings": "2.1.0", "@solana/errors": "2.1.0", "@solana/rpc-spec": "2.1.0", "@solana/rpc-types": "2.1.0" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-1JOBiLFeIeHmGx7k1b23UWF9vM1HAh9GBMCzr5rBPrGSBs+QUgxBJ3+yrRg+UPEOSELubqo7qoOVFUKYsb1nXw=="],
 
@@ -278,6 +304,8 @@
     "@types/uuid": ["@types/uuid@8.3.4", "", {}, "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="],
 
     "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
+
+    "abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
@@ -443,6 +471,8 @@
 
     "isomorphic-ws": ["isomorphic-ws@4.0.1", "", { "peerDependencies": { "ws": "*" } }, "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="],
 
+    "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
+
     "jayson": ["jayson@4.2.0", "", { "dependencies": { "@types/connect": "^3.4.33", "@types/node": "^12.12.54", "@types/ws": "^7.4.4", "commander": "^2.20.3", "delay": "^5.0.0", "es6-promisify": "^5.0.0", "eyes": "^0.1.8", "isomorphic-ws": "^4.0.1", "json-stringify-safe": "^5.0.1", "stream-json": "^1.9.1", "uuid": "^8.3.2", "ws": "^7.5.10" }, "bin": { "jayson": "bin/jayson.js" } }, "sha512-VfJ9t1YLwacIubLhONk0KFeosUBwstRWQ0IRT1KDjEjnVnSOVHC3uwugyV7L0c7R9lpVyrUGT2XWiBA1UTtpyg=="],
 
     "jose": ["jose@6.0.11", "", {}, "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg=="],
@@ -484,6 +514,8 @@
     "os-tmpdir": ["os-tmpdir@1.0.2", "", {}, "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="],
 
     "outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
+
+    "ox": ["ox@0.7.1", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-+k9fY9PRNuAMHRFIUbiK9Nt5seYHHzSQs9Bj+iMETcGtlpS7SmBzcGSVUQO3+nqGLEiNK4598pHNFlVRaZbRsg=="],
 
     "p-filter": ["p-filter@2.1.0", "", { "dependencies": { "p-map": "^2.0.0" } }, "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="],
 
@@ -595,6 +627,8 @@
 
     "uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
+    "viem": ["viem@2.31.0", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.0.8", "isows": "1.0.7", "ox": "0.7.1", "ws": "8.18.2" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-U7OMQ6yqK+bRbEIarf2vqxL7unSEQvNxvML/1zG7suAmKuJmipqdVTVJGKBCJiYsm/EremyO2FS4dHIPpGv+eA=="],
+
     "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
@@ -606,6 +640,8 @@
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
+    "x402": ["x402@0.3.7", "", { "dependencies": { "viem": "^2.23.1", "zod": "^3.24.2" } }, "sha512-8g2sXjWX7UbUNg9wJqgSBoYP7QV3/7qYYssdfPiQM5XDDThuVy7+MnH4cCuQ4UGGn2SVz1hpzWpwxMC3nwp+zA=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -629,6 +665,12 @@
 
     "@elite-agents/oldowan/@types/bun": ["@types/bun@1.2.15", "", { "dependencies": { "bun-types": "1.2.15" } }, "sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA=="],
 
+    "@elite-agents/x402-solana/@types/bun": ["@types/bun@1.2.15", "", { "dependencies": { "bun-types": "1.2.15" } }, "sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA=="],
+
+    "@elite-agents/x402-solana/hono": ["hono@4.7.11", "", {}, "sha512-rv0JMwC0KALbbmwJDEnxvQCeJh+xbS3KEWW5PC9cMJ08Ur9xgatI0HmtgYZfOdOSOeYsp5LO2cOhdI8cLEbDEQ=="],
+
+    "@elite-agents/x402-solana/zod": ["zod@3.25.58", "", {}, "sha512-DVLmMQzSZwNYzQoMaM3MQWnxr2eq+AtM9Hx3w1/Yl0pH8sLTSjN4jGP7w6f7uand6Hw44tsnSu1hz1AOA6qI2Q=="],
+
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
@@ -640,6 +682,8 @@
     "@metaplex-foundation/umi-eddsa-web3js/@metaplex-foundation/umi-web3js-adapters": ["@metaplex-foundation/umi-web3js-adapters@1.1.1", "", { "dependencies": { "buffer": "^6.0.3" }, "peerDependencies": { "@metaplex-foundation/umi": "1.1.1", "@solana/web3.js": "^1.72.0" } }, "sha512-UXP2aY3ce59nSxsVJ4sFLtGCHpesqLTxTag2yI6grCXe0dEz+1kONMn0XFRLcYgiSKOcptJSoJWbILlHnUsWDg=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@3.24.1", "", {}, "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A=="],
+
+    "@scure/bip32/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@solana/errors/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
@@ -667,17 +711,27 @@
 
     "jayson/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
+    "ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "raw-body/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "rpc-websockets/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "solana-oldowan-server/@types/bun": ["@types/bun@1.2.10", "", { "dependencies": { "bun-types": "1.2.10" } }, "sha512-eilv6WFM3M0c9ztJt7/g80BDusK98z/FrFwseZgT4bXCq2vPhXD4z8R3oddmAn+R/Nmz9vBn4kweJKmGTZj+lg=="],
 
+    "viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
+    "viem/ws": ["ws@8.18.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ=="],
+
+    "x402/zod": ["zod@3.25.58", "", {}, "sha512-DVLmMQzSZwNYzQoMaM3MQWnxr2eq+AtM9Hx3w1/Yl0pH8sLTSjN4jGP7w6f7uand6Hw44tsnSu1hz1AOA6qI2Q=="],
+
     "@elite-agents/auth/@types/bun/bun-types": ["bun-types@1.2.15", "", { "dependencies": { "@types/node": "*" } }, "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w=="],
 
     "@elite-agents/machina-habilis/@types/bun/bun-types": ["bun-types@1.2.15", "", { "dependencies": { "@types/node": "*" } }, "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w=="],
 
     "@elite-agents/oldowan/@types/bun/bun-types": ["bun-types@1.2.15", "", { "dependencies": { "@types/node": "*" } }, "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w=="],
+
+    "@elite-agents/x402-solana/@types/bun/bun-types": ["bun-types@1.2.15", "", { "dependencies": { "@types/node": "*" } }, "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w=="],
 
     "@solana/web3.js/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
@@ -701,6 +755,8 @@
 
     "@elite-agents/oldowan/@types/bun/bun-types/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
 
+    "@elite-agents/x402-solana/@types/bun/bun-types/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
+
     "jayson/@types/ws/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
     "solana-oldowan-server/@types/bun/bun-types/@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
@@ -710,6 +766,8 @@
     "@elite-agents/machina-habilis/@types/bun/bun-types/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
     "@elite-agents/oldowan/@types/bun/bun-types/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
+
+    "@elite-agents/x402-solana/@types/bun/bun-types/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
     "solana-oldowan-server/@types/bun/bun-types/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   ],
   "scripts": {
     "build": "bun run --filter './packages/*' --cached build",
-    "build:release": "bun run --filter './packages/oldowan' --cached build:release && bun run --filter './packages/machina-habilis' --cached build:release",
     "dev": "bun run --filter './packages/*' --cached dev",
     "test:ci": "bun test --reporter=junit --reporter-outfile=./junit.xml --coverage",
     "clean": "rm -rf node_modules && rm -rf apps/*/node_modules && rm -rf packages/*/node_modules",
@@ -18,6 +17,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.29.2",
     "@types/bun": "latest",
+    "bun-plugin-dts": "^0.3.0",
     "prettier": "^3.5.0",
     "typescript": "^5.0.0"
   }

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -1,0 +1,113 @@
+# @elite-agents/auth
+
+This package provides utilities for creating and verifying self-signed Distributed Identifier (DID) JSON Web Tokens (JWTs) using Ed25519 key pairs. It focuses on adhering to multibase and multicodec standards for DID key representation.
+
+## Overview: Self-Signed DID JWTs
+
+A self-signed Distributed Identifier (DID) JSON Web Token (JWT) is a JWT where the signature is generated using a private key associated with a DID, and the DID is embedded within the token itself. This approach allows for verifiable self-assertion of identity, enabling applications to securely interact with DIDs and their associated information.
+
+The DID is typically included in the `iss` (issuer) and `sub` (subject) claims of the JWT. The `kid` (key ID) header often references the specific key within the DID document used for signing, usually by including the full DID and a fragment identifier pointing to the key (e.g., `did:key:zExampleDID#zExampleDID`).
+
+## Key Features
+
+*   **DID Key Derivation**: Derives `did:key` identifiers from Ed25519 public keys, encoded using multicodec (`0xed01` for Ed25519 public keys) and multibase (Base58BTC with prefix `z`).
+*   **JWT Generation**: Creates JWTs signed with an Ed25519 private key. The JWT includes the derived DID key in `iss` and `sub` claims, and a `kid` header referencing the DID key.
+*   **JWT Verification**: Verifies self-signed Ed25519 JWTs by:
+    *   Extracting the DID from the `iss` claim.
+    *   Deriving the public key from the DID.
+    *   Validating the JWT signature using the derived public key.
+    *   Checking standard claims like `exp` (expiration), `aud` (audience), and ensuring `iss` and `sub` match.
+    *   Validating the `kid` header.
+*   **Standards Compliant**: Follows `did:key` method specifications, multicodec, and multibase standards.
+*   **Minimal Dependencies**: Relies primarily on the Web Crypto API and the `jose` library for JWT handling and `bs58` for Base58 encoding.
+
+## Core Functions
+
+This package exports the following primary functions from `src/index.ts` (via `src/jwt.ts` and `src/constants.ts`):
+
+*   `deriveDidIdentifierFromEd25519KeyPair(keypair: CryptoKeyPair): Promise<string>`
+    *   Takes an Ed25519 `CryptoKeyPair`.
+    *   Exports the public key, prefixes it with the Ed25519 multicodec (`0xed01`), and then encodes the result using Base58BTC (multibase prefix `z`).
+    *   Returns the `did:key` identifier string (without the `did:key:` prefix itself, just the method-specific identifier part starting with `z`).
+
+*   `generateDidKeyEd25519JWT(aud: string, keypair: CryptoKeyPair, options?: CreateJWTOptions): Promise<string>`
+    *   `aud`: The audience claim for the JWT.
+    *   `keypair`: The Ed25519 `CryptoKeyPair` to sign the JWT.
+    *   `options` (optional):
+        *   `didIdentifier`: An optional, pre-derived DID identifier to use. If not provided, it's derived from the `keypair`.
+        *   `expiresAfterSeconds`: Custom expiration time in seconds (default is 60 seconds).
+    *   Generates a JWT with `iss` and `sub` claims set to `did:key:{didIdentifier}` and `kid` header set to `did:key:{didIdentifier}#{didIdentifier}`.
+    *   Returns the signed JWT string.
+
+*   `verifyDidKeyEd25519JWT(jwt: string, expectedAudience?: string): Promise<JWTPayload>`
+    *   `jwt`: The JWT string to verify.
+    *   `expectedAudience` (optional): The audience the JWT is expected to be for.
+    *   Decodes the JWT, extracts the `iss` claim to get the DID identifier, derives the public key from this identifier, and then verifies the JWT signature and claims (including `kid` header, `iss`, `sub`, `exp`, and `aud`).
+    *   Returns the verified `JWTPayload` if successful; otherwise, throws an error.
+
+## Constants
+
+Key constants are exported from `src/constants.ts`:
+
+*   `ED25519_PUB_MULTICODEC_PREFIX`: `Uint8Array([0xed, 0x01])`
+*   `DID_KEY_PREFIX`: `'did:key:'`
+*   `BASE58BTC_MULTICODEC_PREFIX`: `'z'`
+*   `DEFAULT_EXPIRES_AFTER_SECONDS`: `60` (seconds)
+
+## Usage Example
+
+```typescript
+import {
+  deriveDidIdentifierFromEd25519KeyPair,
+  generateDidKeyEd25519JWT,
+  verifyDidKeyEd25519JWT,
+  DID_KEY_PREFIX
+} from '@elite-agents/auth';
+
+async function main() {
+  // 1. Generate an Ed25519 key pair
+  const keyPair = await crypto.subtle.generateKey(
+    { name: 'Ed25519' },
+    true, // extractable
+    ['sign', 'verify'],
+  );
+
+  // 2. Derive the DID identifier
+  const didIdentifier = await deriveDidIdentifierFromEd25519KeyPair(keyPair);
+  console.log(`Derived DID: ${DID_KEY_PREFIX}${didIdentifier}`);
+
+  // 3. Generate a JWT
+  const audience = 'my-service-audience';
+  const jwt = await generateDidKeyEd25519JWT(audience, keyPair);
+  console.log('Generated JWT:', jwt);
+
+  // 4. Verify the JWT
+  try {
+    const payload = await verifyDidKeyEd25519JWT(jwt, audience);
+    console.log('JWT Verified! Payload:', payload);
+  } catch (error) {
+    console.error('JWT Verification Failed:', error);
+  }
+}
+
+main().catch(console.error);
+```
+
+## Installation
+
+```bash
+npm install @elite-agents/auth
+# or
+yarn add @elite-agents/auth
+# or if using bun
+bun add @elite-agents/auth
+```
+
+## Running Tests
+
+Tests are written using Bun's test runner.
+
+```bash
+cd packages/auth
+bun test
+```

--- a/packages/auth/build-package.ts
+++ b/packages/auth/build-package.ts
@@ -1,0 +1,8 @@
+import dts from 'bun-plugin-dts';
+import { build } from '../../build-script';
+
+await build({
+  entrypoints: ['./src/index.ts'],
+  outdir: './dist',
+  plugins: [dts()],
+});

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@elite-agents/auth",
+  "version": "0.1.0",
+  "module": "src/index.ts",
+  "type": "module",
+  "devDependencies": {
+    "@changesets/cli": "^2.29.2",
+    "@types/bun": "latest",
+    "typescript": "^5.0.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "bs58": "^6.0.0",
+    "jose": "^6.0.11"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts"
+}

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "module": "src/index.ts",
   "type": "module",
+  "scripts": {
+    "build": "bun run build-package"
+  },
   "devDependencies": {
     "@changesets/cli": "^2.29.2",
     "@types/bun": "latest",

--- a/packages/auth/src/constants.ts
+++ b/packages/auth/src/constants.ts
@@ -1,0 +1,5 @@
+export const ED25519_PUB_MULTICODEC_PREFIX = new Uint8Array([0xed, 0x01]);
+export const DID_KEY_PREFIX = 'did:key:';
+export const BASE58BTC_MULTICODEC_PREFIX = 'z';
+export const ED25519_RAW_PUBKEY_LENGTH = 32;
+export const DEFAULT_EXPIRES_AFTER_SECONDS = 60;

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,0 +1,2 @@
+export * from './jwt';
+export * from './constants';

--- a/packages/auth/src/jwt.ts
+++ b/packages/auth/src/jwt.ts
@@ -1,0 +1,226 @@
+import bs58 from 'bs58';
+import { SignJWT, jwtVerify, decodeJwt, type JWTPayload } from 'jose';
+import {
+  BASE58BTC_MULTICODEC_PREFIX,
+  DEFAULT_EXPIRES_AFTER_SECONDS,
+  DID_KEY_PREFIX,
+  ED25519_PUB_MULTICODEC_PREFIX,
+  ED25519_RAW_PUBKEY_LENGTH,
+} from './constants';
+
+/**
+ * Derives a DID identifier for the "did:key" method from an Ed25519 key pair.
+ * This is based on the multicodec specification for ed25519-pub (0xed01).
+ * The multibase prefix for Base58BTC is 'z'.
+ *
+ * @param keypair - The Ed25519 key pair to derive the DID identifier from
+ * @returns The derived DID identifier
+ */
+export const deriveDidIdentifierFromEd25519KeyPair = async (
+  keypair: CryptoKeyPair,
+) => {
+  // 1. Verify the key algorithm and export the public key to raw bytes (ArrayBuffer)
+  if (
+    keypair.publicKey.type !== 'public' ||
+    keypair.publicKey.algorithm.name !== 'Ed25519'
+  ) {
+    throw new Error(
+      `Unsupported public key algorithm: ${keypair.publicKey.algorithm.name}. Expected Ed25519 for multicodec 0xed01.`,
+    );
+  }
+
+  const publicKeyArrayBuffer = await crypto.subtle.exportKey(
+    'raw',
+    keypair.publicKey,
+  );
+
+  // Convert ArrayBuffer to Uint8Array
+  const publicKeyBytes = new Uint8Array(publicKeyArrayBuffer);
+
+  // 2. Create the multicodec prefix for ed25519-pub (0xed01)
+  // This assumes the key is an Ed25519 public key.
+  // The multicodec for ed25519-pub is 0xed01.
+  const multicodecPrefix = ED25519_PUB_MULTICODEC_PREFIX;
+
+  // 3. Concatenate prefix and public key bytes
+  const multicodecPublicKey = new Uint8Array(
+    multicodecPrefix.length + publicKeyBytes.length,
+  );
+  multicodecPublicKey.set(multicodecPrefix, 0);
+  multicodecPublicKey.set(publicKeyBytes, multicodecPrefix.length);
+
+  // 4. Multibase encode: Convert to Base58BTC
+  const hexString = bs58.encode(multicodecPublicKey);
+
+  // 5. Prepend the multibase prefix for Base58BTC ('z')
+  const didIdentifier = BASE58BTC_MULTICODEC_PREFIX + hexString;
+
+  return didIdentifier;
+};
+
+export interface CreateJWTOptions {
+  didIdentifier?: string;
+  expiresAfterSeconds?: number;
+}
+
+/**
+ * Creates a JWT signed with the provided Ed25519 key pair for use with agent authentication.
+ *
+ * @param aud - The intended audience for the JWT (e.g., the server or resource receiving the token).
+ * @param keypair - The Ed25519 key pair used to sign the JWT. The public key will be used to derive a DID identifier if not provided.
+ * @param options - Configuration options for creating the JWT:
+ *   - didIdentifier: (optional) Use this as the DID identifier for the issuer (iss) and subject (sub) fields. If omitted, it is derived from the public key in the keypair.
+ *   - expiresAfterSeconds: (optional) How many seconds until the token expires, relative to now. Defaults to DEFAULT_EXPIRES_AFTER_SECONDS (1 minute).
+ * @returns The signed JWT as a string.
+ */
+export const generateDidKeyEd25519JWT = async (
+  aud: string,
+  keypair: CryptoKeyPair,
+  options: CreateJWTOptions = {},
+): Promise<string> => {
+  const {
+    didIdentifier: providedDidIdentifier,
+    expiresAfterSeconds = DEFAULT_EXPIRES_AFTER_SECONDS,
+  } = options;
+
+  const didIdentifier =
+    providedDidIdentifier ??
+    (await deriveDidIdentifierFromEd25519KeyPair(keypair));
+
+  const iat = Math.floor(Date.now() / 1000);
+  const exp = iat + expiresAfterSeconds;
+
+  const payload = {
+    iss: `did:key:${didIdentifier}`,
+    sub: `did:key:${didIdentifier}`,
+    aud,
+    exp,
+    iat,
+  };
+
+  const jwt = await new SignJWT(payload)
+    .setProtectedHeader({
+      alg: 'EdDSA',
+      typ: 'JWT',
+      kid: `did:key:${didIdentifier}#${didIdentifier}`,
+    })
+    .sign(keypair.privateKey);
+
+  return jwt;
+};
+
+async function getPublicKeyFromDidIdentifier(
+  didIdentifier: string,
+): Promise<CryptoKey> {
+  if (!didIdentifier.startsWith(BASE58BTC_MULTICODEC_PREFIX)) {
+    throw new Error(
+      `Invalid DID identifier: multibase prefix is not '${BASE58BTC_MULTICODEC_PREFIX}'.`,
+    );
+  }
+
+  const multibaseDecoded = bs58.decode(
+    didIdentifier.substring(BASE58BTC_MULTICODEC_PREFIX.length),
+  );
+
+  if (
+    multibaseDecoded.length !==
+    ED25519_PUB_MULTICODEC_PREFIX.length + ED25519_RAW_PUBKEY_LENGTH
+  ) {
+    throw new Error(
+      'Invalid DID identifier: decoded length does not match Ed25519 multicodec key length.',
+    );
+  }
+
+  const decodedPrefix = multibaseDecoded.subarray(
+    0,
+    ED25519_PUB_MULTICODEC_PREFIX.length,
+  );
+  if (
+    !decodedPrefix.every(
+      (val, index) => val === ED25519_PUB_MULTICODEC_PREFIX[index],
+    )
+  ) {
+    throw new Error(
+      'Invalid DID identifier: multicodec prefix is not for Ed25519-pub.',
+    );
+  }
+
+  const rawPublicKeyBytes = multibaseDecoded.subarray(
+    ED25519_PUB_MULTICODEC_PREFIX.length,
+  );
+
+  try {
+    return await crypto.subtle.importKey(
+      'raw',
+      rawPublicKeyBytes,
+      { name: 'Ed25519', namedCurve: 'Ed25519' }, // 'namedCurve' is not strictly needed for Ed25519 but often included
+      true, // make it extractable if needed, though verify does not require it
+      ['verify'],
+    );
+  } catch (error) {
+    throw new Error(
+      `Failed to import public key: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
+ * Verifies a JWT that was signed with an Ed25519 key pair, where the key is identified
+ * by a 'did:key' identifier in the 'iss' and 'sub' claims.
+ *
+ * @param jwt - The JWT string to verify.
+ * @param expectedAudience - (Optional) The expected audience ('aud' claim) of the JWT.
+ * @returns The verified JWT payload if successful.
+ * @throws An error if verification fails (e.g., signature invalid, token expired, claims mismatch).
+ */
+export const verifyDidKeyEd25519JWT = async (
+  jwt: string,
+  expectedAudience?: string,
+): Promise<JWTPayload> => {
+  // 1. Decode JWT to get claims for key extraction (without signature verification yet)
+  let initialPayload: JWTPayload;
+  try {
+    initialPayload = decodeJwt(jwt);
+  } catch (error) {
+    throw new Error(
+      `Invalid JWT format: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  // 2. Validate and extract didIdentifier from 'iss' claim
+  if (
+    !initialPayload.iss ||
+    typeof initialPayload.iss !== 'string' ||
+    !initialPayload.iss.startsWith(DID_KEY_PREFIX)
+  ) {
+    throw new Error(
+      "Invalid or missing 'iss' claim: must be a 'did:key' identifier.",
+    );
+  }
+  if (initialPayload.sub !== initialPayload.iss) {
+    throw new Error("'sub' claim must be identical to 'iss' claim.");
+  }
+  const didIdentifier = initialPayload.iss.substring(DID_KEY_PREFIX.length);
+
+  // 3. Derive public key from didIdentifier
+  const publicKey = await getPublicKeyFromDidIdentifier(didIdentifier);
+
+  // 4. Verify the JWT with the derived public key
+  const { payload, protectedHeader } = await jwtVerify(jwt, publicKey, {
+    algorithms: ['EdDSA'], // Specify EdDSA algorithm
+    issuer: initialPayload.iss, // Verify issuer matches what we expect
+    subject: initialPayload.sub, // Verify subject matches what we expect
+    audience: expectedAudience, // Verify audience if provided
+  });
+
+  // Additional check: Ensure the 'kid' in the header matches the full did:key URI
+  // The kid format is did:key:<method-specific-id>#<method-specific-id>
+  const expectedKid = `${initialPayload.iss}#${didIdentifier}`;
+  if (protectedHeader.kid !== expectedKid) {
+    throw new Error(
+      `Invalid 'kid' in JWT header. Expected '${expectedKid}', got '${protectedHeader.kid}'.`,
+    );
+  }
+
+  return payload;
+};

--- a/packages/auth/src/tests/jwt.test.ts
+++ b/packages/auth/src/tests/jwt.test.ts
@@ -1,0 +1,339 @@
+import { expect, test, describe, beforeEach } from 'bun:test';
+import bs58 from 'bs58';
+import {
+  SignJWT,
+  decodeJwt,
+  decodeProtectedHeader,
+  errors,
+  type JWTPayload,
+} from 'jose';
+
+import {
+  deriveDidIdentifierFromEd25519KeyPair,
+  generateDidKeyEd25519JWT,
+  verifyDidKeyEd25519JWT,
+  DEFAULT_EXPIRES_AFTER_SECONDS,
+  DID_KEY_PREFIX,
+  BASE58BTC_MULTICODEC_PREFIX,
+  ED25519_PUB_MULTICODEC_PREFIX,
+} from '..'; // Assuming this resolves to packages/auth/src/index.ts
+
+describe('DID Key JWT Authentication', () => {
+  let ed25519KeyPair: CryptoKeyPair;
+  let rsaKeyPair: CryptoKeyPair; // For testing non-Ed25519 keys
+
+  // Time mocking has been removed. Tests will use actual system time.
+
+  beforeEach(async () => {
+    ed25519KeyPair = await crypto.subtle.generateKey(
+      { name: 'Ed25519' },
+      true, // extractable
+      ['sign', 'verify'],
+    );
+    rsaKeyPair = await crypto.subtle.generateKey(
+      {
+        name: 'RSASSA-PKCS1-v1_5',
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: 'SHA-256',
+      },
+      true,
+      ['sign', 'verify'],
+    );
+
+    // Time mocking setup removed.
+  });
+
+  // afterEach for time mocking removed.
+
+  describe('deriveDidIdentifierFromEd25519KeyPair', () => {
+    test('should derive a valid DID identifier for an Ed25519 key pair', async () => {
+      const didIdentifier =
+        await deriveDidIdentifierFromEd25519KeyPair(ed25519KeyPair);
+      expect(didIdentifier).toBeString();
+      expect(didIdentifier.startsWith(BASE58BTC_MULTICODEC_PREFIX)).toBe(true);
+
+      const multibaseDecoded = bs58.decode(
+        didIdentifier.substring(BASE58BTC_MULTICODEC_PREFIX.length),
+      );
+      const prefix = multibaseDecoded.subarray(
+        0,
+        ED25519_PUB_MULTICODEC_PREFIX.length,
+      );
+      expect(prefix).toEqual(ED25519_PUB_MULTICODEC_PREFIX);
+      expect(multibaseDecoded.length).toBe(
+        ED25519_PUB_MULTICODEC_PREFIX.length + 32,
+      ); // 32 for raw Ed25519 pubkey
+    });
+
+    test('should throw an error for non-Ed25519 key pairs', async () => {
+      await expect(
+        deriveDidIdentifierFromEd25519KeyPair(rsaKeyPair),
+      ).rejects.toThrow(
+        'Unsupported public key algorithm: RSASSA-PKCS1-v1_5. Expected Ed25519 for multicodec 0xed01.',
+      );
+    });
+  });
+
+  describe('generateDidKeyEd25519JWT', () => {
+    const audience = 'test-audience';
+
+    test('should generate a JWT with correct claims and kid header', async () => {
+      const jwt = await generateDidKeyEd25519JWT(audience, ed25519KeyPair);
+      expect(jwt).toBeString();
+
+      const payload = decodeJwt(jwt);
+      const protectedHeader = decodeProtectedHeader(jwt);
+      const derivedDid =
+        await deriveDidIdentifierFromEd25519KeyPair(ed25519KeyPair);
+
+      expect(payload.iss).toBe(`${DID_KEY_PREFIX}${derivedDid}`);
+      expect(payload.sub).toBe(`${DID_KEY_PREFIX}${derivedDid}`);
+      expect(payload.aud).toBe(audience);
+      expect(typeof payload.iat).toBe('number');
+      expect(typeof payload.exp).toBe('number');
+      // Allow a small delta (e.g., 5 seconds) for processing time and clock differences
+      expect(payload.exp).toBeGreaterThanOrEqual(
+        payload.iat! + DEFAULT_EXPIRES_AFTER_SECONDS - 5,
+      );
+      expect(payload.exp).toBeLessThanOrEqual(
+        payload.iat! + DEFAULT_EXPIRES_AFTER_SECONDS + 5,
+      );
+
+      expect(protectedHeader.alg).toBe('EdDSA');
+      expect(protectedHeader.typ).toBe('JWT');
+      expect(protectedHeader.kid).toBe(
+        `${DID_KEY_PREFIX}${derivedDid}#${derivedDid}`,
+      );
+    });
+
+    test('should use provided didIdentifier if available', async () => {
+      const customDid = 'zCustomTestDID12345';
+      const jwt = await generateDidKeyEd25519JWT(audience, ed25519KeyPair, {
+        didIdentifier: customDid,
+      });
+      const payload = decodeJwt(jwt);
+      const protectedHeader = decodeProtectedHeader(jwt);
+
+      expect(payload.iss).toBe(`${DID_KEY_PREFIX}${customDid}`);
+      expect(payload.sub).toBe(`${DID_KEY_PREFIX}${customDid}`);
+      expect(protectedHeader.kid).toBe(
+        `${DID_KEY_PREFIX}${customDid}#${customDid}`,
+      );
+    });
+
+    test('should use custom expiration if provided', async () => {
+      const customExpires = 60; // 1 minute
+      const jwt = await generateDidKeyEd25519JWT(audience, ed25519KeyPair, {
+        expiresAfterSeconds: customExpires,
+      });
+      const payload = decodeJwt(jwt);
+      expect(typeof payload.iat).toBe('number');
+      expect(typeof payload.exp).toBe('number');
+      // Allow a small delta (e.g., 5 seconds) for processing time
+      expect(payload.exp).toBeGreaterThanOrEqual(
+        payload.iat! + customExpires - 5,
+      );
+      expect(payload.exp).toBeLessThanOrEqual(payload.iat! + customExpires + 5);
+    });
+  });
+
+  describe('verifyDidKeyEd25519JWT', () => {
+    const audience = 'test-audience';
+    let validJwt: string;
+    let derivedDid: string;
+
+    beforeEach(async () => {
+      derivedDid = await deriveDidIdentifierFromEd25519KeyPair(ed25519KeyPair);
+      validJwt = await generateDidKeyEd25519JWT(audience, ed25519KeyPair);
+    });
+
+    test('should successfully verify a valid JWT', async () => {
+      const payload = await verifyDidKeyEd25519JWT(validJwt, audience);
+      expect(payload.iss).toBe(`${DID_KEY_PREFIX}${derivedDid}`);
+      expect(payload.sub).toBe(`${DID_KEY_PREFIX}${derivedDid}`);
+      expect(payload.aud).toBe(audience);
+      expect(typeof payload.iat).toBe('number');
+    });
+
+    test('should fail if JWT is expired', async () => {
+      // Generate a JWT that was issued and expired in the past
+      const pastTimestamp = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
+      const derivedDidForExpiredTest =
+        await deriveDidIdentifierFromEd25519KeyPair(ed25519KeyPair);
+      const expiredJwt = await new SignJWT({ aud: audience })
+        .setProtectedHeader({
+          alg: 'EdDSA',
+          typ: 'JWT',
+          kid: `${DID_KEY_PREFIX}${derivedDidForExpiredTest}#${derivedDidForExpiredTest}`,
+        })
+        .setIssuedAt(pastTimestamp - 60) // Issued 1 hour and 60 seconds ago
+        .setIssuer(`${DID_KEY_PREFIX}${derivedDidForExpiredTest}`)
+        .setSubject(`${DID_KEY_PREFIX}${derivedDidForExpiredTest}`)
+        .setExpirationTime(pastTimestamp) // Expired 1 hour ago
+        .sign(ed25519KeyPair.privateKey);
+
+      await expect(
+        verifyDidKeyEd25519JWT(expiredJwt, audience),
+      ).rejects.toThrow(errors.JWTExpired);
+    });
+
+    test('should fail if audience does not match', async () => {
+      await expect(
+        verifyDidKeyEd25519JWT(validJwt, 'wrong-audience'),
+      ).rejects.toThrow(errors.JWTClaimValidationFailed);
+      // Can also check message: .toThrow(/unexpected "aud" claim value/)
+    });
+
+    test('should succeed if audience in JWT is an array and expected is a string member', async () => {
+      const jwtWithAudArray = await new SignJWT({
+        aud: [audience, 'another-aud'],
+      })
+        .setProtectedHeader({
+          alg: 'EdDSA',
+          typ: 'JWT',
+          kid: `${DID_KEY_PREFIX}${derivedDid}#${derivedDid}`,
+        })
+        .setIssuedAt() // Sets to current time
+        .setIssuer(`${DID_KEY_PREFIX}${derivedDid}`)
+        .setSubject(`${DID_KEY_PREFIX}${derivedDid}`)
+        .setExpirationTime(`${DEFAULT_EXPIRES_AFTER_SECONDS}s`) // Sets relative to current time (e.g., '180s')
+        .sign(ed25519KeyPair.privateKey);
+      const payload = await verifyDidKeyEd25519JWT(jwtWithAudArray, audience);
+      expect(payload.aud).toEqual([audience, 'another-aud']);
+    });
+
+    test('should fail if signature is invalid (tampered JWT)', async () => {
+      const tamperedJwt = validJwt.slice(0, -5) + 'XXXXX';
+      await expect(
+        verifyDidKeyEd25519JWT(tamperedJwt, audience),
+      ).rejects.toThrow(errors.JWSSignatureVerificationFailed);
+    });
+
+    test('should fail if JWT signed with a different key but claims to be from original key', async () => {
+      const anotherKeyPair = await crypto.subtle.generateKey(
+        { name: 'Ed25519' },
+        true,
+        ['sign', 'verify'],
+      );
+      // JWT is signed by anotherKeyPair, but its 'iss' and 'kid' claim to be derived from ed25519KeyPair (derivedDid)
+      const jwtMaliciousIss = await new SignJWT({ aud: audience })
+        .setProtectedHeader({
+          alg: 'EdDSA',
+          typ: 'JWT',
+          kid: `${DID_KEY_PREFIX}${derivedDid}#${derivedDid}`,
+        })
+        .setIssuedAt()
+        .setIssuer(`${DID_KEY_PREFIX}${derivedDid}`)
+        .setSubject(`${DID_KEY_PREFIX}${derivedDid}`)
+        .setExpirationTime(`${DEFAULT_EXPIRES_AFTER_SECONDS}s`)
+        .sign(anotherKeyPair.privateKey);
+
+      await expect(
+        verifyDidKeyEd25519JWT(jwtMaliciousIss, audience),
+      ).rejects.toThrow(errors.JWSSignatureVerificationFailed);
+    });
+
+    test('should fail for malformed did:key in iss (e.g. wrong multicodec)', async () => {
+      // Create a DID with a valid base58btc prefix but an invalid multicodec (e.g., all zeros)
+      const malformedMulticodecBytes = new Uint8Array([
+        0,
+        0,
+        ...new Uint8Array(32).fill(1),
+      ]);
+      const malformedDidIdentifier =
+        BASE58BTC_MULTICODEC_PREFIX + bs58.encode(malformedMulticodecBytes);
+      const malformedIss = `${DID_KEY_PREFIX}${malformedDidIdentifier}`;
+
+      const jwt = await new SignJWT({ aud: audience })
+        .setProtectedHeader({
+          alg: 'EdDSA',
+          typ: 'JWT',
+          kid: `${malformedIss}#${malformedDidIdentifier}`,
+        })
+        .setIssuedAt()
+        .setIssuer(malformedIss)
+        .setSubject(malformedIss)
+        .setExpirationTime('2h')
+        .sign(ed25519KeyPair.privateKey);
+      await expect(verifyDidKeyEd25519JWT(jwt, audience)).rejects.toThrow(
+        'Invalid DID identifier: multicodec prefix is not for Ed25519-pub.',
+      );
+    });
+
+    test('should fail if kid header is missing', async () => {
+      const jwtNoKid = await new SignJWT({ aud: audience })
+        .setProtectedHeader({ alg: 'EdDSA', typ: 'JWT' }) // No kid
+        .setIssuedAt()
+        .setIssuer(`${DID_KEY_PREFIX}${derivedDid}`)
+        .setSubject(`${DID_KEY_PREFIX}${derivedDid}`)
+        .setExpirationTime('2h')
+        .sign(ed25519KeyPair.privateKey);
+      await expect(verifyDidKeyEd25519JWT(jwtNoKid, audience)).rejects.toThrow(
+        /^Invalid 'kid' in JWT header. Expected .* got 'undefined'\.$/,
+      );
+    });
+
+    test('should fail if kid header is malformed', async () => {
+      const jwtWrongKid = await new SignJWT({ aud: audience })
+        .setProtectedHeader({ alg: 'EdDSA', typ: 'JWT', kid: 'wrongkidformat' })
+        .setIssuedAt()
+        .setIssuer(`${DID_KEY_PREFIX}${derivedDid}`)
+        .setSubject(`${DID_KEY_PREFIX}${derivedDid}`)
+        .setExpirationTime('2h')
+        .sign(ed25519KeyPair.privateKey);
+      await expect(
+        verifyDidKeyEd25519JWT(jwtWrongKid, audience),
+      ).rejects.toThrow(
+        /^Invalid 'kid' in JWT header. Expected .* got 'wrongkidformat'\.$/,
+      );
+    });
+
+    test('should fail if iss and sub claims do not match', async () => {
+      const anotherDid = await deriveDidIdentifierFromEd25519KeyPair(
+        await crypto.subtle.generateKey({ name: 'Ed25519' }, true, [
+          'sign',
+          'verify',
+        ]),
+      );
+      const jwt = await new SignJWT({ aud: audience })
+        .setProtectedHeader({
+          alg: 'EdDSA',
+          typ: 'JWT',
+          kid: `${DID_KEY_PREFIX}${derivedDid}#${derivedDid}`,
+        })
+        .setIssuedAt()
+        .setIssuer(`${DID_KEY_PREFIX}${derivedDid}`)
+        .setSubject(`${DID_KEY_PREFIX}${anotherDid}`) // Different sub
+        .setExpirationTime('2h')
+        .sign(ed25519KeyPair.privateKey);
+      await expect(verifyDidKeyEd25519JWT(jwt, audience)).rejects.toThrow(
+        "'sub' claim must be identical to 'iss' claim.",
+      );
+    });
+
+    test('should fail if iss claim is not a did:key identifier', async () => {
+      const jwt = await new SignJWT({ aud: audience })
+        .setProtectedHeader({
+          alg: 'EdDSA',
+          typ: 'JWT',
+          kid: `notadidkey#notadidkey`,
+        })
+        .setIssuedAt()
+        .setIssuer(`notadidkey`) // Not a did:key
+        .setSubject(`notadidkey`)
+        .setExpirationTime('2h')
+        .sign(ed25519KeyPair.privateKey);
+      await expect(verifyDidKeyEd25519JWT(jwt, audience)).rejects.toThrow(
+        "Invalid or missing 'iss' claim: must be a 'did:key' identifier.",
+      );
+    });
+
+    test('should fail for completely malformed JWT string', async () => {
+      const malformedJwt = 'this.is.not.a.jwt';
+      await expect(
+        verifyDidKeyEd25519JWT(malformedJwt, audience),
+      ).rejects.toThrow(/^Invalid JWT format:/);
+    });
+  });
+});

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -4,6 +4,9 @@
     // Options specific to this package or overriding the base config
     // "noEmit" from the base is overridden by "outDir" and "declaration"
     // Other options like "lib", "target", "module", "strict", etc., are inherited.
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]

--- a/packages/machina-habilis/build-package.ts
+++ b/packages/machina-habilis/build-package.ts
@@ -1,0 +1,9 @@
+import dts from 'bun-plugin-dts';
+import { build } from '../../build-script';
+
+await build({
+  entrypoints: ['./src/index.ts'],
+  outdir: './dist',
+  external: ['@solana/kit', 'openai', 'hono', 'zod'],
+  plugins: [dts()],
+});

--- a/packages/machina-habilis/package.json
+++ b/packages/machina-habilis/package.json
@@ -4,19 +4,19 @@
   "module": "src/index.ts",
   "type": "module",
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir ./dist --external @solana/kit --external openai --external hono --external zod && bun run build:types",
-    "build:release": "bun run build",
-    "dev": "bun run build --watch",
-    "build:types": "tsc --emitDeclarationOnly"
+    "build": "bun run build-package",
+    "dev": "bun run build --watch"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.2",
     "@elite-agents/oldowan": "workspace:*",
+    "@elite-agents/auth": "workspace:*",
     "@types/bun": "latest",
     "typescript": "^5.0.0"
   },
   "bundledDependencies": [
-    "@elite-agents/oldowan"
+    "@elite-agents/oldowan",
+    "@elite-agents/auth"
   ],
   "files": [
     "dist"

--- a/packages/machina-habilis/src/HTTPClientEd25519AuthenticatedTransport.ts
+++ b/packages/machina-habilis/src/HTTPClientEd25519AuthenticatedTransport.ts
@@ -1,0 +1,169 @@
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import {
+  type JSONRPCMessage,
+  JSONRPCMessageSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import {
+  deriveDidIdentifierFromEd25519KeyPair,
+  generateDidKeyEd25519JWT,
+} from '@elite-agents/auth';
+
+/**
+ * Implements the {@link Transport} interface for client-side communication to MCP servers
+ * using authenticated HTTP POST requests. This transport sends and receives JSON-RPC messages.
+ *
+ * It authenticates requests to `tools/call` methods by generating a DID Key JWT
+ * using the provided Ed25519 keypair.
+ *
+ * This transport does not use streaming; it makes individual HTTP requests for each message
+ * and expects a JSON response.
+ */
+export class HTTPClientEd25519AuthenticatedTransport implements Transport {
+  private _url: URL;
+  private _keypair: CryptoKeyPair;
+  private _requestInit?: RequestInit;
+  private _didIdentifier?: string;
+
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+
+  /**
+   * Constructs an instance of HTTPClientAuthenticatedTransport.
+   *
+   * @param url The URL of the MCP server endpoint.
+   * @param opts Configuration options for the transport.
+   * @param opts.requestInit Optional `RequestInit` object for customizing fetch requests (e.g., adding custom headers).
+   * @param opts.keypair The Ed25519 `CryptoKeyPair` used to generate a DID Key for authenticating `tools/call` requests.
+   */
+  constructor(
+    url: URL,
+    opts: {
+      requestInit?: RequestInit;
+      keypair: CryptoKeyPair;
+    },
+  ) {
+    this._url = url;
+    this._keypair = opts.keypair;
+    this._requestInit = opts?.requestInit;
+
+    this._deriveDidIdentifier();
+  }
+
+  /**
+   * Derives the DID (Decentralized Identifier) key string from the Ed25519 public key.
+   * The DID is used in the 'kid' (Key ID) header of the JWT for `tools/call` requests.
+   * Stores the derived identifier in `this._didIdentifier`.
+   *
+   * @private
+   * @returns A promise that resolves to the derived DID identifier string.
+   */
+  private async _deriveDidIdentifier() {
+    const didIdentifier = await deriveDidIdentifierFromEd25519KeyPair(
+      this._keypair,
+    );
+
+    this._didIdentifier = didIdentifier;
+
+    return didIdentifier;
+  }
+
+  /**
+   * Initializes the transport. For this HTTP-based transport, no specific setup is required
+   * beyond what's done in the constructor.
+   *
+   * @returns A promise that resolves when the transport is ready.
+   */
+  async start(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  /**
+   * Closes the transport connection. Triggers the `onclose` callback if registered.
+   * For this HTTP transport, there's no persistent connection to close, so this method
+   * primarily serves to notify listeners.
+   *
+   * @returns A promise that resolves when the close operation is complete.
+   */
+  async close(): Promise<void> {
+    this.onclose?.();
+  }
+
+  /**
+   * Sends a JSON-RPC message to the MCP server via an HTTP POST request.
+   *
+   * If the message method includes 'tools/call', it generates a DID Key JWT
+   * using the provided keypair and includes it in the 'Authorization' header.
+   *
+   * Notifications (methods including 'notification') are sent without expecting a response.
+   * For other messages, it expects a JSON-RPC response, which is then parsed and passed
+   * to the `onmessage` callback. Errors during the request or response parsing are passed
+   * to the `onerror` callback.
+   *
+   * @param message The JSON-RPC message to send.
+   * @returns A promise that resolves when the message has been sent and a response processed (if applicable).
+   *          It throws an error if the HTTP request fails or the response is not OK.
+   */
+  async send(message: JSONRPCMessage): Promise<void> {
+    if ('method' in message && message.method.includes('notification')) {
+      // Notifications are not expected to have a response
+      return;
+    }
+
+    try {
+      const headers = new Headers(this._requestInit?.headers);
+      headers.set('content-type', 'application/json');
+
+      if ('method' in message && message.method.includes('tools/call')) {
+        // set auth header here if method is 'tools/call'
+
+        const didIdentifier =
+          this._didIdentifier ?? (await this._deriveDidIdentifier());
+
+        const jwt = await generateDidKeyEd25519JWT(
+          this._url.toString(),
+          this._keypair,
+          {
+            didIdentifier,
+          },
+        );
+
+        const authHeader = `Bearer ${jwt}`;
+        headers.set('Authorization', authHeader);
+      }
+
+      const init = {
+        ...this._requestInit,
+        method: 'POST',
+        headers,
+        body: JSON.stringify(message),
+      };
+
+      const response = await fetch(this._url, init);
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => null);
+        throw new Error(
+          `Error POSTing to endpoint (HTTP ${response.status}): ${text}`,
+        );
+      }
+
+      // Parse the response as JSON and process it as a message if available
+      const contentType = response.headers.get('content-type');
+      if (contentType?.includes('application/json')) {
+        try {
+          const data = await response.json();
+          const responseMessage = JSONRPCMessageSchema.parse(data);
+          this.onmessage?.(responseMessage);
+        } catch (error) {
+          this.onerror?.(
+            new Error(`Failed to parse response as JSON RPC message: ${error}`),
+          );
+        }
+      }
+    } catch (error) {
+      this.onerror?.(error as Error);
+      throw error;
+    }
+  }
+}

--- a/packages/machina-habilis/src/index.ts
+++ b/packages/machina-habilis/src/index.ts
@@ -3,6 +3,7 @@ export * from './machina';
 export * from './persona';
 export * from './types';
 export * from './mnemon';
+export * from './HTTPClientEd25519AuthenticatedTransport';
 export * from './HTTPClientTransport';
 export {
   deriveToolUniqueName,

--- a/packages/oldowan/build-cli.ts
+++ b/packages/oldowan/build-cli.ts
@@ -1,0 +1,9 @@
+import dts from 'bun-plugin-dts';
+import { build } from '../../build-script';
+
+await build({
+  entrypoints: ['./src/cli.ts'],
+  outdir: './dist',
+  target: 'node',
+  plugins: [dts()],
+});

--- a/packages/oldowan/build-package.ts
+++ b/packages/oldowan/build-package.ts
@@ -1,0 +1,17 @@
+import dts from 'bun-plugin-dts';
+import { build } from '../../build-script';
+
+await build({
+  entrypoints: ['./src/index.ts'],
+  outdir: './dist',
+  external: [
+    '@modelcontextprotocol/sdk',
+    '@readme/openapi-schemas',
+    '@solana/kit',
+    'commander',
+    'hono',
+    'jsonschema',
+    'zod',
+  ],
+  plugins: [dts()],
+});

--- a/packages/oldowan/package.json
+++ b/packages/oldowan/package.json
@@ -7,15 +7,17 @@
     "oldowan": "./dist/cli.js"
   },
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir ./dist --packages external && bun build ./src/cli.ts --outdir ./dist --target bun && bun run build:types",
-    "build:release": "bun build ./src/index.ts --outdir ./dist --packages external && bun build ./src/cli.ts --outdir ./dist --target node && bun run build:types",
-    "dev": "bun run build --watch",
-    "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist"
+    "build": "bun run build-package && bun run build-cli",
+    "dev": "bun run build --watch"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.2",
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "@elite-agents/auth": "workspace:*"
   },
+  "bundledDependencies": [
+    "@elite-agents/auth"
+  ],
   "peerDependencies": {
     "typescript": "^5.0.0"
   },

--- a/packages/oldowan/src/oldowan-tool.ts
+++ b/packages/oldowan/src/oldowan-tool.ts
@@ -1,46 +1,28 @@
 import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
-import { type PaymentDetails, type ToolAuthArg } from './types';
-import {
-  verifySignature,
-  type SignatureBytes,
-  getBase58Encoder,
-} from '@solana/kit';
-import { generateDeterministicPayloadForSigning } from './utils';
-import { ED25519_ALGORITHM_IDENTIFIER } from './crypto';
 
 export class OldowanTool<T extends z.ZodRawShape> {
   name: string;
   description: string;
   schema: T;
   call: (input: Record<string, unknown>) => Promise<CallToolResult>;
-  paymentDetails?: PaymentDetails;
 
   constructor({
     name,
     description,
     schema,
     execute,
-    paymentDetails,
   }: {
     name: string;
     description: string;
     schema: T;
     execute: (input: z.infer<z.ZodObject<T>>) => Promise<unknown>;
-    paymentDetails?: PaymentDetails;
   }) {
-    if ('auth' in schema) {
-      throw new Error(
-        `The field 'auth' is reserved and cannot be defined in the tool schema.`,
-      );
-    }
-
     this.name = name;
     this.description = description;
     this.schema = schema;
     this.call = (input: Record<string, unknown>) =>
       this.toolCall(input, execute);
-    this.paymentDetails = paymentDetails;
   }
 
   async toolCall(
@@ -49,55 +31,6 @@ export class OldowanTool<T extends z.ZodRawShape> {
   ) {
     try {
       const validatedInput = await this.validateInput(args);
-
-      if (this.paymentDetails) {
-        // if there is no paymentDetails, then no signature check is required
-        // for best performance
-
-        if (!args.auth)
-          throw new Error(
-            'No authentication payload provided. You are not allowed to call this tool.',
-          );
-
-        const { signatureBase64Url, publicKeyBase58, nonce } =
-          args.auth as ToolAuthArg;
-
-        const currentTimestamp = Date.now();
-
-        // if the nonce is more than 3 minutes old, then the signature is invalid
-        if (currentTimestamp - nonce > 3 * 60 * 1000) {
-          throw new Error('Invalid signature. Signature is too old.');
-        }
-
-        const payload = generateDeterministicPayloadForSigning(
-          validatedInput,
-          nonce,
-        );
-
-        const publicKey = await crypto.subtle.importKey(
-          'raw',
-          getBase58Encoder().encode(publicKeyBase58),
-          ED25519_ALGORITHM_IDENTIFIER,
-          true,
-          ['verify'],
-        );
-
-        const verified = await verifySignature(
-          publicKey,
-          new Uint8Array(
-            Buffer.from(signatureBase64Url, 'base64url'),
-          ) as SignatureBytes,
-          payload,
-        );
-
-        if (!verified) {
-          throw new Error(
-            'Invalid signature. You are not allowed to call this tool.',
-          );
-        }
-
-        // TODO: now check payment based on the public key
-      }
 
       const result = await cb(validatedInput);
       return this.createSuccessResponse(result);

--- a/packages/oldowan/src/types.ts
+++ b/packages/oldowan/src/types.ts
@@ -58,31 +58,42 @@ export type IEndpointDefinition = z.infer<typeof ZEndpointDefinition>;
 export type OpenAPIParameter = z.infer<typeof ZOpenAPIParameter>;
 export type OpenAPIRequestBody = z.infer<typeof ZOpenAPIRequestBody>;
 
-export const TokenGatedPaymentDetailsSchema = z.object({
+export const PaymentDetailsBaseSchema = z.object({
+  description: z.string().optional(),
+});
+
+export const TokenGatedPaymentDetailsSchema = PaymentDetailsBaseSchema.extend({
   type: z.literal('token-gated'),
   chain: z.literal('solana'),
   tokenAddress: z.string(),
   amountUi: z.number(),
-  description: z.string().optional(),
 });
 
-export const SubscriptionPaymentDetailsSchema = z.object({
-  type: z.literal('subscription'),
-  planId: z.string(),
-  description: z.string().optional(),
-});
+export const SubscriptionPaymentDetailsSchema = PaymentDetailsBaseSchema.extend(
+  {
+    type: z.literal('subscription'),
+    planId: z.string(),
+  },
+);
 
-export const CreditPaymentDetailsSchema = z.object({
+export const CreditPaymentDetailsSchema = PaymentDetailsBaseSchema.extend({
   type: z.literal('credit'),
   amount: z.number(),
   creditId: z.string(),
-  description: z.string().optional(),
+});
+
+export const PayPerUsePaymentDetailsSchema = PaymentDetailsBaseSchema.extend({
+  type: z.literal('pay-per-use'),
+  chain: z.literal('solana'),
+  tokenAddress: z.string(),
+  amountUi: z.number(),
 });
 
 export const PaymentDetailsSchema = z.discriminatedUnion('type', [
   TokenGatedPaymentDetailsSchema,
   SubscriptionPaymentDetailsSchema,
   CreditPaymentDetailsSchema,
+  PayPerUsePaymentDetailsSchema,
 ]);
 
 export type PaymentDetails = z.infer<typeof PaymentDetailsSchema>;

--- a/packages/oldowan/tsconfig.json
+++ b/packages/oldowan/tsconfig.json
@@ -1,29 +1,8 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    // Enable latest features
-    "lib": ["ESNext", "DOM"],
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleDetection": "force",
-    "jsx": "react-jsx",
-    "allowJs": true,
-
-    // Bundler mode
-    "moduleResolution": "bundler",
-    "verbatimModuleSyntax": true,
-
-    // Best practices
-    "strict": true,
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-
-    // Some stricter flags (disabled by default)
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noPropertyAccessFromIndexSignature": false,
-    "rootDir": "src",
-    "outDir": "dist",
-    "declaration": true
+    "outDir": "dist"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
 }

--- a/packages/x402-solana/build-package.ts
+++ b/packages/x402-solana/build-package.ts
@@ -1,0 +1,8 @@
+import dts from 'bun-plugin-dts';
+import { build } from '../../build-script';
+
+await build({
+  entrypoints: ['./src/index.ts'],
+  outdir: './dist',
+  plugins: [dts()],
+});

--- a/packages/x402-solana/package.json
+++ b/packages/x402-solana/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@elite-agents/x402-solana",
+  "version": "0.1.0",
+  "module": "src/index.ts",
+  "type": "module",
+  "scripts": {
+    "build": "bun run build-package"
+  },
+  "devDependencies": {
+    "@changesets/cli": "^2.29.2",
+    "@types/bun": "latest",
+    "typescript": "^5.0.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "hono": "^4.7.11",
+    "x402": "^0.3.7",
+    "zod": "^3.25.58"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts"
+}

--- a/packages/x402-solana/src/index.ts
+++ b/packages/x402-solana/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './payment-middleware';

--- a/packages/x402-solana/src/payment-middleware.ts
+++ b/packages/x402-solana/src/payment-middleware.ts
@@ -1,0 +1,266 @@
+import type { Context } from 'hono';
+import type { Address } from 'viem';
+import { exact } from 'x402/schemes';
+import {
+  computeRoutePatterns,
+  findMatchingPaymentRequirements,
+  findMatchingRoute,
+  getPaywallHtml,
+  processPriceToAtomicAmount,
+  toJsonSafe,
+} from 'x402/shared';
+import {
+  type FacilitatorConfig,
+  moneySchema,
+  type PaymentPayload,
+  type PaymentRequirements,
+  type Resource,
+  type RoutesConfig,
+  settleResponseHeader,
+} from 'x402/types';
+import { useFacilitator } from 'x402/verify';
+
+/**
+ * Creates a payment middleware factory for Hono
+ *
+ * @param payTo - The address to receive payments
+ * @param routes - Configuration for protected routes and their payment requirements
+ * @param facilitator - Optional configuration for the payment facilitator service
+ * @returns A Hono middleware handler
+ *
+ * @example
+ * ```typescript
+ * // Simple configuration - All endpoints are protected by $0.01 of USDC on base-sepolia
+ * app.use(paymentMiddleware(
+ *   '0x123...', // payTo address
+ *   {
+ *     price: '$0.01', // USDC amount in dollars
+ *     network: 'base-sepolia'
+ *   },
+ *   // Optional facilitator configuration. Defaults to x402.org/facilitator for testnet usage
+ * ));
+ *
+ * // Advanced configuration - Endpoint-specific payment requirements & custom facilitator
+ * app.use(paymentMiddleware('0x123...', // payTo: The address to receive payments
+ *   {
+ *     '/weather/*': {
+ *       price: '$0.001', // USDC amount in dollars
+ *       network: 'base',
+ *       config: {
+ *         description: 'Access to weather data'
+ *       }
+ *     }
+ *   },
+ *   {
+ *     url: 'https://facilitator.example.com',
+ *     createAuthHeaders: async () => ({
+ *       verify: { "Authorization": "Bearer token" },
+ *       settle: { "Authorization": "Bearer token" }
+ *     })
+ *   }
+ * ));
+ * ```
+ */
+export function paymentMiddleware(
+  payTo: Address,
+  routes: RoutesConfig,
+  facilitator?: FacilitatorConfig,
+) {
+  const { verify, settle } = useFacilitator(facilitator);
+  const x402Version = 1;
+
+  // Pre-compile route patterns to regex and extract verbs
+  const routePatterns = computeRoutePatterns(routes);
+
+  return async function paymentMiddleware(
+    c: Context,
+    next: () => Promise<void>,
+  ) {
+    const matchingRoute = findMatchingRoute(
+      routePatterns,
+      c.req.path,
+      c.req.method.toUpperCase(),
+    );
+    if (!matchingRoute) {
+      return next();
+    }
+
+    const { price, network } = matchingRoute.config;
+    const {
+      description,
+      mimeType,
+      maxTimeoutSeconds,
+      outputSchema,
+      customPaywallHtml,
+      resource,
+    } = matchingRoute.config.config || {};
+
+    const atomicAmountForAsset = processPriceToAtomicAmount(price, network);
+    if ('error' in atomicAmountForAsset) {
+      throw new Error(atomicAmountForAsset.error);
+    }
+    const { maxAmountRequired, asset } = atomicAmountForAsset;
+
+    const resourceUrl: Resource = resource || (c.req.url as Resource);
+
+    const paymentRequirements: PaymentRequirements[] = [
+      {
+        scheme: 'exact',
+        network,
+        maxAmountRequired,
+        resource: resourceUrl,
+        description: description ?? '',
+        mimeType: mimeType ?? 'application/json',
+        payTo,
+        maxTimeoutSeconds: maxTimeoutSeconds ?? 300,
+        asset: asset?.address ?? '',
+        outputSchema,
+        extra: asset?.eip712,
+      },
+    ];
+
+    const payment = c.req.header('X-PAYMENT');
+    const userAgent = c.req.header('User-Agent') || '';
+    const acceptHeader = c.req.header('Accept') || '';
+    const isWebBrowser =
+      acceptHeader.includes('text/html') && userAgent.includes('Mozilla');
+
+    if (!payment) {
+      if (isWebBrowser) {
+        let displayAmount: number;
+        if (typeof price === 'string' || typeof price === 'number') {
+          const parsed = moneySchema.safeParse(price);
+          if (parsed.success) {
+            displayAmount = parsed.data;
+          } else {
+            displayAmount = Number.NaN;
+          }
+        } else {
+          displayAmount = Number(price.amount) / 10 ** price.asset.decimals;
+        }
+
+        const currentUrl =
+          new URL(c.req.url).pathname + new URL(c.req.url).search;
+        const html =
+          customPaywallHtml ??
+          getPaywallHtml({
+            amount: displayAmount,
+            paymentRequirements: toJsonSafe(paymentRequirements) as Parameters<
+              typeof getPaywallHtml
+            >[0]['paymentRequirements'],
+            currentUrl,
+            testnet: network === 'base-sepolia',
+          });
+        return c.html(html, 402);
+      }
+      return c.json(
+        {
+          error: 'X-PAYMENT header is required',
+          accepts: paymentRequirements,
+          x402Version,
+        },
+        402,
+      );
+    }
+
+    // Verify payment
+    let decodedPayment: PaymentPayload;
+    try {
+      decodedPayment = exact.evm.decodePayment(payment);
+      decodedPayment.x402Version = x402Version;
+    } catch (error) {
+      return c.json(
+        {
+          error:
+            error instanceof Error
+              ? error
+              : new Error('Invalid or malformed payment header'),
+          accepts: paymentRequirements,
+          x402Version,
+        },
+        402,
+      );
+    }
+
+    const selectedPaymentRequirements = findMatchingPaymentRequirements(
+      paymentRequirements,
+      decodedPayment,
+    );
+    if (!selectedPaymentRequirements) {
+      return c.json(
+        {
+          error: 'Unable to find matching payment requirements',
+          accepts: toJsonSafe(paymentRequirements),
+          x402Version,
+        },
+        402,
+      );
+    }
+
+    const verification = await verify(
+      decodedPayment,
+      selectedPaymentRequirements,
+    );
+
+    if (!verification.isValid) {
+      return c.json(
+        {
+          error: new Error(verification.invalidReason),
+          accepts: paymentRequirements,
+          payer: verification.payer,
+          x402Version,
+        },
+        402,
+      );
+    }
+
+    // Proceed with request
+    await next();
+
+    let res = c.res;
+
+    // If the response from the protected route is >= 400, do not settle payment
+    if (res.status >= 400) {
+      return;
+    }
+
+    c.res = undefined;
+
+    // Settle payment before processing the request, as Hono middleware does not allow us to set headers after the response has been sent
+    try {
+      const settlement = await settle(
+        decodedPayment,
+        selectedPaymentRequirements,
+      );
+      if (settlement.success) {
+        const responseHeader = settleResponseHeader(settlement);
+        res.headers.set('X-PAYMENT-RESPONSE', responseHeader);
+      } else {
+        throw new Error(settlement.errorReason);
+      }
+    } catch (error) {
+      res = c.json(
+        {
+          error:
+            error instanceof Error
+              ? error
+              : new Error('Failed to settle payment'),
+          accepts: paymentRequirements,
+          x402Version,
+        },
+        402,
+      );
+    }
+
+    c.res = res;
+  };
+}
+
+export type {
+  Money,
+  Network,
+  PaymentMiddlewareConfig,
+  Resource,
+  RouteConfig,
+  RoutesConfig,
+} from 'x402/types';

--- a/packages/x402-solana/src/types.ts
+++ b/packages/x402-solana/src/types.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+
+export const schemes = [
+  'exact',
+  'token-gated',
+  'subscription',
+  'credit',
+] as const;
+
+const isInteger = (value: string) =>
+  Number.isInteger(Number(value)) && Number(value) >= 0;
+
+const AddressRegex = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+export const NetworkSchema = z.enum([
+  'base-sepolia',
+  'base',
+  'avalanche-fuji',
+  'avalanche',
+  'iotex',
+  'solana',
+]);
+
+// Base schema with common fields
+const PaymentRequirementsBaseSchema = z.object({
+  network: NetworkSchema,
+  maxAmountRequired: z.string().refine(isInteger),
+  resource: z.string().url(),
+  description: z.string(),
+  mimeType: z.string(),
+  outputSchema: z.record(z.any()).optional(),
+  payTo: z.string().regex(AddressRegex),
+  maxTimeoutSeconds: z.number().int(),
+  asset: z.string().regex(AddressRegex),
+});
+
+// Schema for 'exact' payment
+const ExactPaymentRequirementsSchema = PaymentRequirementsBaseSchema.extend({
+  scheme: z.literal('exact'),
+  extra: z.record(z.any()).optional(),
+});
+
+// Schema for 'token-gated' payment
+const TokenGatedPaymentRequirementsSchema =
+  PaymentRequirementsBaseSchema.extend({
+    scheme: z.literal('token-gated'),
+    network: z.literal('solana'),
+    extra: z.object({
+      tokenAddress: z.string(),
+      amountUi: z.number(),
+    }),
+  });
+
+// Schema for 'subscription' payment
+const SubscriptionPaymentRequirementsSchema =
+  PaymentRequirementsBaseSchema.extend({
+    scheme: z.literal('subscription'),
+    extra: z.object({
+      planId: z.string(),
+    }),
+  });
+
+// Schema for 'credit' payment
+const CreditPaymentRequirementsSchema = PaymentRequirementsBaseSchema.extend({
+  scheme: z.literal('credit'),
+  extra: z.object({
+    amount: z.number(),
+    creditId: z.string(),
+  }),
+});
+
+// x402PaymentRequirements discriminated union
+export const PaymentRequirementsSchema = z.discriminatedUnion('scheme', [
+  ExactPaymentRequirementsSchema,
+  TokenGatedPaymentRequirementsSchema,
+  SubscriptionPaymentRequirementsSchema,
+  CreditPaymentRequirementsSchema,
+]);
+
+export type PaymentRequirements = z.infer<typeof PaymentRequirementsSchema>;

--- a/packages/x402-solana/tsconfig.json
+++ b/packages/x402-solana/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // Options specific to this package or overriding the base config
+    // "noEmit" from the base is overridden by "outDir" and "declaration"
+    // Other options like "lib", "target", "module", "strict", etc., are inherited.
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
-    "noEmit": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
 
     // Best practices
     "strict": true,
@@ -22,6 +23,15 @@
     // Some stricter flags (disabled by default)
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "noPropertyAccessFromIndexSignature": false
-  }
+    "noPropertyAccessFromIndexSignature": false,
+    "baseUrl": ".",
+    "paths": {
+      "@elite-agents/auth": ["./packages/auth/src/index.ts"],
+      "@elite-agents/machina-habilis": [
+        "./packages/machina-habilis/src/index.ts"
+      ],
+      "@elite-agents/oldowan": ["./packages/oldowan/src/index.ts"]
+    }
+  },
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
 }


### PR DESCRIPTION
Going to further modularize this repo:

`auth`: this will contain the logic for creating Bearer tokens for communication between the AI Client and the MCP Server. This is then used to verify the ownership of certain gating tokens.

`x402-solana`: this will contain our implementation for the x402 spec on solana. This is the foundation layer that simply allows for `pay-per-use` of a resource (MCP or not). Implementing this as a Hono / Express middleware.

`oldowan`: will further add to the oldowan package a middleware that expands upon `x402-solana` to allow for using `auth` to check for the ownership of a token or a subscription PDA.